### PR TITLE
Fix searching by state

### DIFF
--- a/oio_rest/oio_rest/db.py
+++ b/oio_rest/oio_rest/db.py
@@ -218,7 +218,13 @@ def sql_convert_registration(registration, class_name):
     sql_states = []
     for sn in get_state_names(class_name):
         qsn = class_name.lower() + sn  # qualified_state_name
-        periods = states[qsn] if qsn in states else None
+        if qsn in states:
+            periods = states[qsn]
+        elif sn in states:
+            periods = states[sn]
+        else:
+            periods = None
+
         sql_states.append(
             sql_state_array(sn, periods, class_name)
         )

--- a/oio_rest/oio_rest/db_helpers.py
+++ b/oio_rest/oio_rest/db_helpers.py
@@ -68,13 +68,6 @@ def get_state_names(class_name):
     return db_struct[class_name.lower()]['tilstande']
 
 
-def get_state_field(class_name, state_name):
-    """Return the name of the state field for the given state.
-    This usually follows the convention of appending 'status' to the end.
-    """
-    return state_name + 'status'
-
-
 _relation_names = {}
 
 

--- a/oio_rest/oio_rest/utils/build_registration.py
+++ b/oio_rest/oio_rest/utils/build_registration.py
@@ -2,7 +2,7 @@ import uuid
 from werkzeug.datastructures import MultiDict
 
 from ..db_helpers import get_attribute_names, get_attribute_fields
-from ..db_helpers import get_state_names, get_relation_names, get_state_field
+from ..db_helpers import get_state_names, get_relation_names
 from ..db_helpers import get_document_part_relation_names
 from ..db_helpers import DokumentVariantEgenskaberType
 from ..db_helpers import DokumentDelEgenskaberType
@@ -124,14 +124,11 @@ def build_registration(class_name, list_args):
 
         state = registration.setdefault('states', {})
         for state_name in get_state_names(class_name):
-            state_field_name = get_state_field(class_name,
-                                               state_name)
-
             state_periods = state.setdefault(state_name, [])
-            if f == state_field_name:
+            if f == state_name:
                 for state_value in list_args[f]:
                     state_periods.append({
-                        state_field_name: state_value,
+                        state_name: state_value,
                         'virkning': None
                     })
 


### PR DESCRIPTION
LoRA supports restricting searches by state similar to how it supports
attribute and relation restrictions. Unfortunately however, that code
was broken. The main culprit was inconsistent use if field and
attribute names. With this change, the following works as expected:

?organisationenhedgyldighed=Aktiv