### PR TITLE
Feature/21656 virkningstid

### DIFF
--- a/doc/API-NOTES.rst
+++ b/doc/API-NOTES.rst
@@ -233,6 +233,14 @@ giving the "actual state" as the results.
 The results that are returned are filtered by those that overlap with the
 given date/time ranges.
 
+Alternatively the following parameters can be used: ::
+
+   &virkningstid=<datotid>
+   &registreringstid=<datotid>
+
+The results returned will be those valid at date/time value <datotid>, giving a
+'snapshot' of the object's state at a given point in time.
+
 List operation
 --------------
 

--- a/oio_rest/oio_rest/db_helpers.py
+++ b/oio_rest/oio_rest/db_helpers.py
@@ -99,6 +99,7 @@ GENERAL_SEARCH_PARAMS = {
 TEMPORALITY_PARAMS = {
     'registreretfra',
     'registrerettil',
+    'registreringstid',
     'virkningfra',
     'virkningtil',
     'virkningstid',

--- a/oio_rest/oio_rest/db_helpers.py
+++ b/oio_rest/oio_rest/db_helpers.py
@@ -101,6 +101,7 @@ TEMPORALITY_PARAMS = {
     'registrerettil',
     'virkningfra',
     'virkningtil',
+    'virkningstid',
 }
 
 

--- a/oio_rest/oio_rest/oio_rest.py
+++ b/oio_rest/oio_rest/oio_rest.py
@@ -43,23 +43,21 @@ def typed_get(d, field, default):
 
 
 def get_virkning_dates(args):
-    virkning_fra = args.get('virkningfra', None)
-    virkning_til = args.get('virkningtil', None)
-    virkningstid = args.get('virkningstid', None)
+    virkning_fra = args.get('virkningfra')
+    virkning_til = args.get('virkningtil')
+    virkningstid = args.get('virkningstid')
 
-    if virkningstid and (virkning_fra or virkning_til):
-        raise BadRequestException("'virkningfra'/'virkningtil' are not "
-                                  "supported parameters with "
-                                  "'virkningstid'")
-
-    if virkning_fra is None and virkning_til is None:
-        if virkningstid:
-            # Timespan has to be non-zero length of time, so we add one
-            # microsecond
-            dt = dateutil.parser.isoparse(virkningstid)
-            virkning_fra = dt
-            virkning_til = dt + datetime.timedelta(microseconds=1)
-        else:
+    if virkningstid:
+        if virkning_fra or virkning_til:
+            raise BadRequestException("'virkningfra'/'virkningtil' conflict "
+                                      "with 'virkningstid'")
+        # Timespan has to be non-zero length of time, so we add one
+        # microsecond
+        dt = dateutil.parser.isoparse(virkningstid)
+        virkning_fra = dt
+        virkning_til = dt + datetime.timedelta(microseconds=1)
+    else:
+        if virkning_fra is None and virkning_til is None:
             # TODO: Use the equivalent of TSTZRANGE(current_timestamp,
             # current_timestamp,'[]') if possible
             virkning_fra = datetime.datetime.now()
@@ -69,15 +67,14 @@ def get_virkning_dates(args):
 
 
 def get_registreret_dates(args):
-    registreret_fra = args.get('registreretfra', None)
-    registreret_til = args.get('registrerettil', None)
-    registreringstid = args.get('registreringstid', None)
+    registreret_fra = args.get('registreretfra')
+    registreret_til = args.get('registrerettil')
+    registreringstid = args.get('registreringstid')
 
     if registreringstid:
         if registreret_fra or registreret_til:
             raise BadRequestException("'registreretfra'/'registrerettil' "
-                                      "are not supported parameters with "
-                                      "'registreringstid'")
+                                      "conflict with 'registreringstid'")
         else:
             # Timespan has to be non-zero length of time, so we add one
             # microsecond

--- a/oio_rest/oio_rest/oio_rest.py
+++ b/oio_rest/oio_rest/oio_rest.py
@@ -3,7 +3,7 @@
 import json
 import datetime
 
-from dateutil import parser
+import dateutil
 from flask import jsonify, request
 from custom_exceptions import BadRequestException, NotFoundException
 from custom_exceptions import GoneException
@@ -56,7 +56,7 @@ def get_virkning_dates(args):
         if virkningstid:
             # Timespan has to be non-zero length of time, so we add one
             # microsecond
-            dt = parser.parse(virkningstid)
+            dt = dateutil.parser.isoparse(virkningstid)
             virkning_fra = dt
             virkning_til = dt + datetime.timedelta(microseconds=1)
         else:
@@ -81,7 +81,7 @@ def get_registreret_dates(args):
         else:
             # Timespan has to be non-zero length of time, so we add one
             # microsecond
-            dt = parser.parse(registreringstid)
+            dt = dateutil.parser.isoparse(registreringstid)
             registreret_fra = dt
             registreret_til = dt + datetime.timedelta(microseconds=1)
     return registreret_fra, registreret_til

--- a/oio_rest/setup.py
+++ b/oio_rest/setup.py
@@ -55,7 +55,7 @@ setup(
         'wsgiref==0.1.2',
         'python-saml==2.4.0',
         'pexpect==3.3',
-        'python-dateutil==2.6.0',
+        'python-dateutil==2.7.0',
         'egenix-mx-base==3.2.9',
         'pika',
     ],

--- a/oio_rest/tests/fixtures/output/test_bruger_virkningstid.json
+++ b/oio_rest/tests/fixtures/output/test_bruger_virkningstid.json
@@ -1,0 +1,43 @@
+{
+    "attributter": {
+        "brugeregenskaber": [
+            {
+                "brugernavn": "Testbruger",
+                "brugervendtnoegle": "andersand",
+                "virkning": {
+                    "from": "-infinity",
+                    "from_included": true,
+                    "to": "infinity",
+                    "to_included": false
+                }
+            }
+        ]
+    },
+    "relationer": {
+        "tilknyttedepersoner": [
+            {
+                "urn": "urn:dk:cpr:person:2222222222",
+                "virkning": {
+                    "from": "2002-02-14 00:00:00+01",
+                    "from_included": true,
+                    "to": "2012-02-14 00:00:00+01",
+                    "to_included": false
+                }
+            }
+        ]
+    },
+    "tilstande": {
+        "brugergyldighed": [
+            {
+                "gyldighed": "Aktiv",
+                "virkning": {
+                    "from": "2002-02-14 00:00:00+01",
+                    "from_included": true,
+                    "to": "infinity",
+                    "to_included": false
+                }
+            }
+        ]
+    },
+    "livscykluskode": "Importeret"
+}

--- a/oio_rest/tests/fixtures/test_bruger.json
+++ b/oio_rest/tests/fixtures/test_bruger.json
@@ -1,0 +1,51 @@
+{
+    "attributter": {
+        "brugeregenskaber": [
+            {
+                "brugernavn": "Testbruger",
+                "brugervendtnoegle": "andersand",
+                "virkning": {
+                    "from": "-infinity",
+                    "from_included": true,
+                    "to": "infinity",
+                    "to_included": false
+                }
+            }
+        ]
+    },
+    "relationer": {
+        "tilknyttedepersoner": [
+            {
+                "urn": "urn:dk:cpr:person:2222222222",
+                "virkning": {
+                    "from": "2002-02-14T00:00:00+01:00",
+                    "from_included": true,
+                    "to": "2012-02-14T00:00:00+01:00",
+                    "to_included": false
+                }
+            },
+            {
+                "urn": "urn:dk:cpr:person:1111111111",
+                "virkning": {
+                    "from": "2012-02-14T00:00:00+01:00",
+                    "from_included": true,
+                    "to": "infinity",
+                    "to_included": false
+                }
+            }
+        ]
+    },
+    "tilstande": {
+        "brugergyldighed": [
+            {
+                "gyldighed": "Aktiv",
+                "virkning": {
+                    "from": "2002-02-14T00:00:00+01:00",
+                    "from_included": true,
+                    "to": "infinity",
+                    "to_included": false
+                }
+            }
+        ]
+    }
+}

--- a/oio_rest/tests/test_integration_oio_rest.py
+++ b/oio_rest/tests/test_integration_oio_rest.py
@@ -20,7 +20,5 @@ class Tests(util.TestCase):
         expected = util.get_fixture(
             'output/test_bruger_virkningstid.json')
 
-        actual = self.get_json_result('/organisation/bruger', uuid=uuid,
-                                      virkningstid='2004-01-01')
-
-        self.assertRegistrationsEqual(expected, actual)
+        self.assertQueryResponse(expected, '/organisation/bruger',
+                                 uuid=uuid, virkningstid='2004-01-01')

--- a/oio_rest/tests/test_integration_oio_rest.py
+++ b/oio_rest/tests/test_integration_oio_rest.py
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2017-2018, Magenta ApS
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+import json
+
+from . import util
+
+
+class Tests(util.TestCase):
+
+    def test_virkningstid(self):
+        uuid = "931ee7bf-10d6-4cc3-8938-83aa6389aaba"
+
+        self.load_fixture('/organisation/bruger', 'test_bruger.json', uuid)
+
+        expected = util.get_fixture(
+            'output/test_bruger_virkningstid.json')
+
+        actual = self.get_json_result('/organisation/bruger', uuid=uuid,
+                                      virkningstid='2004-01-01')
+
+        self.assertRegistrationsEqual(expected, actual)

--- a/oio_rest/tests/test_oio_rest.py
+++ b/oio_rest/tests/test_oio_rest.py
@@ -402,7 +402,8 @@ class TestOIORestObject(TestCase):
 
         virkning_fra = datetime.datetime.now()
         virkning_to = datetime.datetime.now() + datetime.timedelta(
-                microseconds=1)
+            microseconds=1
+        )
 
         expected_args = (
             'TestClassRestObject', None, "REGISTRATION", virkning_fra,
@@ -553,7 +554,7 @@ class TestOIORestObject(TestCase):
 
         virkning_fra = datetime.datetime.now()
         virkning_to = datetime.datetime.now() + datetime.timedelta(
-                microseconds=1)
+            microseconds=1)
 
         expected_args = ('TestClassRestObject', [uuid], virkning_fra,
                          virkning_to, None, None)
@@ -875,6 +876,126 @@ class TestOIORestObject(TestCase):
                                            query_string=params), \
                 self.assertRaises(BadRequestException):
             self.testclass.delete_object(uuid)
+
+    def test_get_virkning_timespan_virkningstid(self):
+        # Arrange
+        args = {
+            'virkningstid': '2020-01-01',
+        }
+
+        expected_from = datetime.datetime(2020, 1, 1)
+        expected_to = expected_from + datetime.timedelta(microseconds=1)
+
+        # Act
+        actual_from, actual_to = self.testclass.get_virkning_timespan(args)
+
+        # Assert
+        self.assertEqual(expected_from, actual_from)
+        self.assertEqual(expected_to, actual_to)
+
+    def test_get_virkning_timespan_from_to(self):
+        # Arrange
+        args = {
+            'virkningfra': '2006-01-01',
+            'virkningtil': '2020-01-01',
+        }
+
+        expected_from = '2006-01-01'
+        expected_to = '2020-01-01'
+
+        # Act
+        actual_from, actual_to = self.testclass.get_virkning_timespan(args)
+
+        # Assert
+        self.assertEqual(expected_from, actual_from)
+        self.assertEqual(expected_to, actual_to)
+
+    @freezegun.freeze_time('2017-01-01', tz_offset=1)
+    def test_get_virkning_timespan_defaults(self):
+        # Arrange
+        args = {}
+
+        expected_from = datetime.datetime(2017, 1, 1, 1)
+        expected_to = expected_from + datetime.timedelta(microseconds=1)
+
+        # Act
+        actual_from, actual_to = self.testclass.get_virkning_timespan(args)
+
+        # Assert
+        self.assertEqual(expected_from, actual_from)
+        self.assertEqual(expected_to, actual_to)
+
+    def test_get_virkning_timespan_raises_on_invalid_args_combination(self):
+        # Arrange
+        args = {
+            'virkningstid': '2020-01-01',
+            'virkningfra': '2006-01-01',
+            'virkningtil': '2020-01-01',
+        }
+
+        # Act
+        with self.assertRaises(BadRequestException):
+            self.testclass.get_virkning_timespan(args)
+
+    def test_get_registreret_timespan_registreringstid(self):
+        # Arrange
+        args = {
+            'registreringstid': '2020-01-01',
+        }
+
+        expected_from = datetime.datetime(2020, 1, 1)
+        expected_to = expected_from + datetime.timedelta(microseconds=1)
+
+        # Act
+        actual_from, actual_to = self.testclass.get_registreret_timespan(args)
+
+        # Assert
+        self.assertEqual(expected_from, actual_from)
+        self.assertEqual(expected_to, actual_to)
+
+    def test_get_registreret_timespan_from_to(self):
+        # Arrange
+        args = {
+            'registreretfra': '2006-01-01',
+            'registrerettil': '2020-01-01',
+        }
+
+        expected_from = '2006-01-01'
+        expected_to = '2020-01-01'
+
+        # Act
+        actual_from, actual_to = self.testclass.get_registreret_timespan(args)
+
+        # Assert
+        self.assertEqual(expected_from, actual_from)
+        self.assertEqual(expected_to, actual_to)
+
+    @freezegun.freeze_time('2017-01-01', tz_offset=1)
+    def test_get_registreret_timespan_defaults(self):
+        # Arrange
+        args = {}
+
+        expected_from = None
+        expected_to = None
+
+        # Act
+        actual_from, actual_to = self.testclass.get_registreret_timespan(args)
+
+        # Assert
+        self.assertEqual(expected_from, actual_from)
+        self.assertEqual(expected_to, actual_to)
+
+    def test_get_registreret_timespan_raises_on_invalid_args_combination(self):
+        # Arrange
+        args = {
+            'registreringstid': '2020-01-01',
+            'registreretfra': '2006-01-01',
+            'registrerettil': '2020-01-01',
+        }
+
+        # Act
+        with self.assertRaises(BadRequestException):
+            self.testclass.get_registreret_timespan(args)
 
 
 class TestOIOStandardHierarchy(TestCase):

--- a/oio_rest/tests/test_oio_rest.py
+++ b/oio_rest/tests/test_oio_rest.py
@@ -299,21 +299,22 @@ class TestOIORestObject(TestCase):
                 self.assertRaises(BadRequestException):
             self.testclass.get_fields()
 
-    @patch('datetime.datetime')
+    @freezegun.freeze_time('2017-01-01', tz_offset=1)
     @patch('oio_rest.oio_rest.db.list_objects')
     @patch('oio_rest.db_helpers.db_struct', new=db_struct)
     def test_get_objects_list_uses_default_params(self,
-                                                  mock_list,
-                                                  mock_datetime):
+                                                  mock_list):
         # Arrange
         data = ["1", "2", "3"]
 
         mock_list.return_value = data
 
-        now = "NOW"
-        mock_datetime.now.return_value = now
+        virkning_fra = datetime.datetime.now()
+        virkning_to = datetime.datetime.now() + datetime.timedelta(
+            microseconds=1)
 
-        expected_args = ('TestClassRestObject', None, now, now, None, None)
+        expected_args = ('TestClassRestObject', None, virkning_fra,
+                         virkning_to, None, None)
 
         expected_result = {"results": data}
 
@@ -386,12 +387,12 @@ class TestOIORestObject(TestCase):
 
         self.assertDictEqual(expected_result, actual_result)
 
+    @freezegun.freeze_time('2017-01-01', tz_offset=1)
     @patch('oio_rest.db_helpers.db_struct', new=db_struct)
-    @patch('datetime.datetime')
     @patch('oio_rest.oio_rest.build_registration')
     @patch('oio_rest.oio_rest.db.search_objects')
-    def test_get_objects_search_uses_default_params(self, mock_search, mock_br,
-                                                    mock_datetime):
+    def test_get_objects_search_uses_default_params(self, mock_search,
+                                                    mock_br):
         # Arrange
         data = ["1", "2", "3"]
 
@@ -399,12 +400,13 @@ class TestOIORestObject(TestCase):
 
         mock_br.return_value = "REGISTRATION"
 
-        now = "NOW"
-        mock_datetime.now.return_value = now
+        virkning_fra = datetime.datetime.now()
+        virkning_to = datetime.datetime.now() + datetime.timedelta(
+                microseconds=1)
 
         expected_args = (
-            'TestClassRestObject', None, "REGISTRATION", now, now,
-            None, None, None, None, None, None, None, None, None)
+            'TestClassRestObject', None, "REGISTRATION", virkning_fra,
+            virkning_to, None, None, None, None, None, None, None, None, None)
 
         expected_result = {"results": data}
 
@@ -549,9 +551,12 @@ class TestOIORestObject(TestCase):
 
         mock_list.return_value = [data]
 
-        now = datetime.datetime.now()
+        virkning_fra = datetime.datetime.now()
+        virkning_to = datetime.datetime.now() + datetime.timedelta(
+                microseconds=1)
 
-        expected_args = ('TestClassRestObject', [uuid], now, now, None, None)
+        expected_args = ('TestClassRestObject', [uuid], virkning_fra,
+                         virkning_to, None, None)
 
         expected_result = {uuid: data}
 

--- a/oio_rest/tests/test_oio_rest.py
+++ b/oio_rest/tests/test_oio_rest.py
@@ -877,125 +877,6 @@ class TestOIORestObject(TestCase):
                 self.assertRaises(BadRequestException):
             self.testclass.delete_object(uuid)
 
-    def test_get_virkning_timespan_virkningstid(self):
-        # Arrange
-        args = {
-            'virkningstid': '2020-01-01',
-        }
-
-        expected_from = datetime.datetime(2020, 1, 1)
-        expected_to = expected_from + datetime.timedelta(microseconds=1)
-
-        # Act
-        actual_from, actual_to = self.testclass.get_virkning_timespan(args)
-
-        # Assert
-        self.assertEqual(expected_from, actual_from)
-        self.assertEqual(expected_to, actual_to)
-
-    def test_get_virkning_timespan_from_to(self):
-        # Arrange
-        args = {
-            'virkningfra': '2006-01-01',
-            'virkningtil': '2020-01-01',
-        }
-
-        expected_from = '2006-01-01'
-        expected_to = '2020-01-01'
-
-        # Act
-        actual_from, actual_to = self.testclass.get_virkning_timespan(args)
-
-        # Assert
-        self.assertEqual(expected_from, actual_from)
-        self.assertEqual(expected_to, actual_to)
-
-    @freezegun.freeze_time('2017-01-01', tz_offset=1)
-    def test_get_virkning_timespan_defaults(self):
-        # Arrange
-        args = {}
-
-        expected_from = datetime.datetime(2017, 1, 1, 1)
-        expected_to = expected_from + datetime.timedelta(microseconds=1)
-
-        # Act
-        actual_from, actual_to = self.testclass.get_virkning_timespan(args)
-
-        # Assert
-        self.assertEqual(expected_from, actual_from)
-        self.assertEqual(expected_to, actual_to)
-
-    def test_get_virkning_timespan_raises_on_invalid_args_combination(self):
-        # Arrange
-        args = {
-            'virkningstid': '2020-01-01',
-            'virkningfra': '2006-01-01',
-            'virkningtil': '2020-01-01',
-        }
-
-        # Act
-        with self.assertRaises(BadRequestException):
-            self.testclass.get_virkning_timespan(args)
-
-    def test_get_registreret_timespan_registreringstid(self):
-        # Arrange
-        args = {
-            'registreringstid': '2020-01-01',
-        }
-
-        expected_from = datetime.datetime(2020, 1, 1)
-        expected_to = expected_from + datetime.timedelta(microseconds=1)
-
-        # Act
-        actual_from, actual_to = self.testclass.get_registreret_timespan(args)
-
-        # Assert
-        self.assertEqual(expected_from, actual_from)
-        self.assertEqual(expected_to, actual_to)
-
-    def test_get_registreret_timespan_from_to(self):
-        # Arrange
-        args = {
-            'registreretfra': '2006-01-01',
-            'registrerettil': '2020-01-01',
-        }
-
-        expected_from = '2006-01-01'
-        expected_to = '2020-01-01'
-
-        # Act
-        actual_from, actual_to = self.testclass.get_registreret_timespan(args)
-
-        # Assert
-        self.assertEqual(expected_from, actual_from)
-        self.assertEqual(expected_to, actual_to)
-
-    @freezegun.freeze_time('2017-01-01', tz_offset=1)
-    def test_get_registreret_timespan_defaults(self):
-        # Arrange
-        args = {}
-
-        expected_from = None
-        expected_to = None
-
-        # Act
-        actual_from, actual_to = self.testclass.get_registreret_timespan(args)
-
-        # Assert
-        self.assertEqual(expected_from, actual_from)
-        self.assertEqual(expected_to, actual_to)
-
-    def test_get_registreret_timespan_raises_on_invalid_args_combination(self):
-        # Arrange
-        args = {
-            'registreringstid': '2020-01-01',
-            'registreretfra': '2006-01-01',
-            'registrerettil': '2020-01-01',
-        }
-
-        # Act
-        with self.assertRaises(BadRequestException):
-            self.testclass.get_registreret_timespan(args)
 
 
 class TestOIOStandardHierarchy(TestCase):
@@ -1103,3 +984,123 @@ class TestOIORest(TestCase):
         # Act & Assert
         with self.assertRaises(BadRequestException):
             oio_rest.typed_get(d, testkey, default)
+
+    def test_get_virkning_dates_virkningstid(self):
+        # Arrange
+        args = {
+            'virkningstid': '2020-01-01',
+        }
+
+        expected_from = datetime.datetime(2020, 1, 1)
+        expected_to = expected_from + datetime.timedelta(microseconds=1)
+
+        # Act
+        actual_from, actual_to = oio_rest.get_virkning_dates(args)
+
+        # Assert
+        self.assertEqual(expected_from, actual_from)
+        self.assertEqual(expected_to, actual_to)
+
+    def test_get_virkning_dates_from_to(self):
+        # Arrange
+        args = {
+            'virkningfra': '2006-01-01',
+            'virkningtil': '2020-01-01',
+        }
+
+        expected_from = '2006-01-01'
+        expected_to = '2020-01-01'
+
+        # Act
+        actual_from, actual_to = oio_rest.get_virkning_dates(args)
+
+        # Assert
+        self.assertEqual(expected_from, actual_from)
+        self.assertEqual(expected_to, actual_to)
+
+    @freezegun.freeze_time('2017-01-01', tz_offset=1)
+    def test_get_virkning_dates_defaults(self):
+        # Arrange
+        args = {}
+
+        expected_from = datetime.datetime(2017, 1, 1, 1)
+        expected_to = expected_from + datetime.timedelta(microseconds=1)
+
+        # Act
+        actual_from, actual_to = oio_rest.get_virkning_dates(args)
+
+        # Assert
+        self.assertEqual(expected_from, actual_from)
+        self.assertEqual(expected_to, actual_to)
+
+    def test_get_virkning_dates_raises_on_invalid_args_combination(self):
+        # Arrange
+        args = {
+            'virkningstid': '2020-01-01',
+            'virkningfra': '2006-01-01',
+            'virkningtil': '2020-01-01',
+        }
+
+        # Act
+        with self.assertRaises(BadRequestException):
+            oio_rest.get_virkning_dates(args)
+
+    def test_get_registreret_dates_registreringstid(self):
+        # Arrange
+        args = {
+            'registreringstid': '2020-01-01',
+        }
+
+        expected_from = datetime.datetime(2020, 1, 1)
+        expected_to = expected_from + datetime.timedelta(microseconds=1)
+
+        # Act
+        actual_from, actual_to = oio_rest.get_registreret_dates(args)
+
+        # Assert
+        self.assertEqual(expected_from, actual_from)
+        self.assertEqual(expected_to, actual_to)
+
+    def test_get_registreret_dates_from_to(self):
+        # Arrange
+        args = {
+            'registreretfra': '2006-01-01',
+            'registrerettil': '2020-01-01',
+        }
+
+        expected_from = '2006-01-01'
+        expected_to = '2020-01-01'
+
+        # Act
+        actual_from, actual_to = oio_rest.get_registreret_dates(args)
+
+        # Assert
+        self.assertEqual(expected_from, actual_from)
+        self.assertEqual(expected_to, actual_to)
+
+    @freezegun.freeze_time('2017-01-01', tz_offset=1)
+    def test_get_registreret_dates_defaults(self):
+        # Arrange
+        args = {}
+
+        expected_from = None
+        expected_to = None
+
+        # Act
+        actual_from, actual_to = oio_rest.get_registreret_dates(args)
+
+        # Assert
+        self.assertEqual(expected_from, actual_from)
+        self.assertEqual(expected_to, actual_to)
+
+    def test_get_registreret_dates_raises_on_invalid_args_combination(self):
+        # Arrange
+        args = {
+            'registreringstid': '2020-01-01',
+            'registreretfra': '2006-01-01',
+            'registrerettil': '2020-01-01',
+        }
+
+        # Act
+        with self.assertRaises(BadRequestException):
+            oio_rest.get_registreret_dates(args)

--- a/oio_rest/tests/util.py
+++ b/oio_rest/tests/util.py
@@ -269,7 +269,7 @@ class TestCaseMixin(object):
         return self.assertRegistrationsEqual(expected, actual)
 
     def load_fixture(self, path, fixture_name, uuid=None):
-        """Load a fixture, i.e. a JSON file with the 'fixtures' directory,
+        """Load a fixture, i.e. a JSON file in the 'fixtures' directory,
         into LoRA at the given path & UUID.
         """
         if uuid:
@@ -279,6 +279,10 @@ class TestCaseMixin(object):
         else:
             r = self._perform_request(path, method='POST',
                                       json=get_fixture(fixture_name))
+
+        self.assertLess(r.status_code, 300)
+        self.assertGreaterEqual(r.status_code, 200)
+
         return r
 
 


### PR DESCRIPTION
Implemented 'virkningstid' and 'registreringstid', making it possible to view an objects state at specific points in time.
We already had the functionality in place as the default behaviour if no virkningstid was specified, I simply generalized it a bit to work on arbitrary points in time, and used the same approach for registrations.