### PR TITLE
Feature/19357 seperation of python agents

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -90,7 +90,6 @@ echo "Installing Agents"
 $DIR/agents/install.sh "$DOMAIN"
 
 # Exclude legacy python_agents (MOX Advis, Mox Elk Log)
-# For more info, please see $REPOSITORY_ROOT/python_agents/README.rst
 # $DIR/python_agents/install.py
 
 echo

--- a/install.sh
+++ b/install.sh
@@ -88,7 +88,10 @@ echo "$DIR/agentbase/python/mox" > "$DIR/agentbase/python/mox/mox.pth"
 # Compile agents
 echo "Installing Agents"
 $DIR/agents/install.sh "$DOMAIN"
-$DIR/python_agents/install.py
+
+# Exclude legacy python_agents (MOX Advis, Mox Elk Log)
+# For more info, please see $REPOSITORY_ROOT/python_agents/README.rst
+# $DIR/python_agents/install.py
 
 echo
 echo "Install succeeded!!!"

--- a/python_agents/README.rst
+++ b/python_agents/README.rst
@@ -3,11 +3,11 @@ MOX python agents
 
 This directory contains the following 2 (legacy) mox agents:
 
-    +-------------+----------------+
-    | MOX Advis   | mox_advis.py   |
-    +-------------+----------------+
-    | MOX Elk Log | mox_elk_log.py |
-    +-------------+ ---------------+
++-------------+----------------+
+| MOX Advis   | mox_advis.py   |
++-------------+----------------+
+| MOX Elk Log | mox_elk_log.py |
++-------------+ ---------------+
 
 These agents were part of the early iterations of the Lora stack.
 However these agents not used in the current release (may be added in the forseeable future).

--- a/python_agents/README.rst
+++ b/python_agents/README.rst
@@ -1,0 +1,21 @@
+MOX python agents
+=================
+
+This directory contains the following 2 (legacy) mox agents:
+    * MOX Advis (mox_advis.py)
+    * MOX Elk Log (mox_elk_log.py)
+
+These agents were part of the early iterations of the Lora stack.
+However these agents not used in the upcoming releases (for the forseeable future).
+
+As such the agents have been excluded from the default installation procedure,
+until the code base is evalutated and updated.
+
+Update/Dependencies
+-------------------
+
+MOX Advis & MOX Elk Log have previouly been coupled with the OIO Rest package.
+The agents have now been de-coupled and do not depend on external settings and python dependencies.
+
+However the agents depend on a local OIO Rest module: saml2.py (Saml2_Assertion class).
+This dependecy is not currently up-to-date and will be either removed or refactored.

--- a/python_agents/README.rst
+++ b/python_agents/README.rst
@@ -2,14 +2,17 @@ MOX python agents
 =================
 
 This directory contains the following 2 (legacy) mox agents:
-    * MOX Advis (mox_advis.py)
-    * MOX Elk Log (mox_elk_log.py)
+
+    +-------------+----------------+
+    | MOX Advis   | mox_advis.py   |
+    +-------------+----------------+
+    | MOX Elk Log | mox_elk_log.py |
+    +-------------+ ---------------+
 
 These agents were part of the early iterations of the Lora stack.
 However these agents not used in the current release (may be added in the forseeable future).
 
-As such the agents have been excluded from the default installation procedure
-until the code base is evaluated and updated.
+The two agents are currently unsupported and not part of the default installation procedure.
 
 Update/Dependencies
 -------------------

--- a/python_agents/README.rst
+++ b/python_agents/README.rst
@@ -6,10 +6,10 @@ This directory contains the following 2 (legacy) mox agents:
     * MOX Elk Log (mox_elk_log.py)
 
 These agents were part of the early iterations of the Lora stack.
-However these agents not used in the upcoming releases (for the forseeable future).
+However these agents not used in the current release (may be added in the forseeable future).
 
-As such the agents have been excluded from the default installation procedure,
-until the code base is evalutated and updated.
+As such the agents have been excluded from the default installation procedure
+until the code base is evaluated and updated.
 
 Update/Dependencies
 -------------------
@@ -18,4 +18,5 @@ MOX Advis & MOX Elk Log have previouly been coupled with the OIO Rest package.
 The agents have now been de-coupled and do not depend on external settings and python dependencies.
 
 However the agents depend on a local OIO Rest module: saml2.py (Saml2_Assertion class).
-This dependecy is not currently up-to-date and will be either removed or refactored.
+This dependency is not Python 3 compatible
+and will be removed or refactored when the code is moved to Python 3.

--- a/python_agents/mox_advis.py
+++ b/python_agents/mox_advis.py
@@ -6,11 +6,14 @@ import logging
 import requests
 
 from email.mime.text import MIMEText
-from settings import MOX_ADVIS_QUEUE, OIOREST_SERVER, FROM_EMAIL
+from settings import MOX_ADVIS_QUEUE
+from settings import OIOREST_SERVER
+from settings import FROM_EMAIL
 from settings import ADVIS_SUBJECT_PREFIX
 from settings import MOX_ADVIS_LOG_FILE
+from settings import SAML_MOX_ENTITY_ID
+from settings import SAML_IDP_ENTITY_ID
 
-from oio_rest.settings import SAML_MOX_ENTITY_ID, SAML_IDP_ENTITY_ID
 from oio_rest.auth.saml2 import Saml2_Assertion
 
 from mox_agent import MOXAgent, unpack_saml_token, get_idp_cert

--- a/python_agents/mox_advis.py
+++ b/python_agents/mox_advis.py
@@ -14,6 +14,10 @@ from settings import MOX_ADVIS_LOG_FILE
 from settings import SAML_MOX_ENTITY_ID
 from settings import SAML_IDP_ENTITY_ID
 
+# TODO:
+# In order to refactor the SAML related import(s)
+# We must first extract the Saml2_Assertion class
+# into its own library
 from oio_rest.auth.saml2 import Saml2_Assertion
 
 from mox_agent import MOXAgent, unpack_saml_token, get_idp_cert

--- a/python_agents/mox_elk_log.py
+++ b/python_agents/mox_elk_log.py
@@ -8,7 +8,9 @@ import requests
 from settings import MOX_LOG_EXCHANGE, MOX_OBJECT_EXCHANGE, DO_LOG_TO_AMQP
 from settings import MOX_ELK_LOG_FILE, IS_LOG_AUTHENTICATION_ENABLED
 
-from oio_rest.settings import SAML_MOX_ENTITY_ID, SAML_IDP_ENTITY_ID
+from settings import SAML_MOX_ENTITY_ID
+from settings import SAML_IDP_ENTITY_ID
+
 from oio_rest.auth.saml2 import Saml2_Assertion
 
 from mox_agent import MOXAgent, unpack_saml_token, get_idp_cert

--- a/python_agents/mox_elk_log.py
+++ b/python_agents/mox_elk_log.py
@@ -11,6 +11,10 @@ from settings import MOX_ELK_LOG_FILE, IS_LOG_AUTHENTICATION_ENABLED
 from settings import SAML_MOX_ENTITY_ID
 from settings import SAML_IDP_ENTITY_ID
 
+# TODO:
+# In order to refactor the SAML related import(s)
+# We must first extract the Saml2_Assertion class
+# into its own library
 from oio_rest.auth.saml2 import Saml2_Assertion
 
 from mox_agent import MOXAgent, unpack_saml_token, get_idp_cert

--- a/python_agents/mox_elk_log.py
+++ b/python_agents/mox_elk_log.py
@@ -17,12 +17,11 @@ from settings import SAML_IDP_ENTITY_ID
 # into its own library
 from oio_rest.auth.saml2 import Saml2_Assertion
 
-from mox_agent import MOXAgent, unpack_saml_token, get_idp_cert
+from settings import MOX_LOGSTASH_URI
+from settings import MOX_LOGSTASH_USER
+from settings import MOX_LOGSTASH_PASS
 
-# Logstash configuration
-logstash_url = 'http://139.162.183.253:42998'
-logstash_user = 'hunter2'
-logstash_password = 'fghTJ425245ADCFVd'
+from mox_agent import MOXAgent, unpack_saml_token, get_idp_cert
 
 
 class MOXELKLog(MOXAgent):
@@ -79,8 +78,8 @@ class MOXELKLog(MOXAgent):
         else:
             print "Posting to logstash ..."
             data = json.loads(body)  # noqa
-            r = requests.post(logstash_url, body, auth=(logstash_user,
-                                                        logstash_password))
+            r = requests.post(MOX_LOGSTASH_URI, body, auth=(MOX_LOGSTASH_USER,
+                                                            MOX_LOGSTASH_PASS))
             print "Done: ", r
 
 

--- a/python_agents/requirements.txt
+++ b/python_agents/requirements.txt
@@ -1,0 +1,6 @@
+certifi==2018.1.18
+chardet==3.0.4
+idna==2.6
+pika==0.11.2
+requests==2.18.4
+urllib3==1.22

--- a/python_agents/settings.py
+++ b/python_agents/settings.py
@@ -37,3 +37,8 @@ SAML_MOX_ENTITY_ID = env('MOX_SAML_MOX_ENTITY_ID', 'https://localhost')
 # Legacy
 TEST_PUBLIC_KEY = os.path.join(DIR, 'test_auth_data/idp-certificate.pem')
 SAML_IDP_CERTIFICATE = env('MOX_SAML_IDP_CERTIFICATE', TEST_PUBLIC_KEY)
+
+# Logstash settings
+MOX_LOGSTASH_URI = env('MOX_LOGSTASH_URI', 'http://127.0.0.1:42998')
+MOX_LOGSTASH_USER = env('MOX_LOGSTASH_USER', 'mox_logstash_user')
+MOX_LOGSTASH_PASS = env('MOX_LOGSTASH_PASS', 'secretlogstashpassword')

--- a/python_agents/settings.py
+++ b/python_agents/settings.py
@@ -3,24 +3,33 @@ import os
 
 DIR = os.path.dirname(__file__)
 
-AMQP_SERVER = 'localhost'
+# Settings
+# Use environment variable or fallback value
 
-MOX_ADVIS_QUEUE = 'Advis'
-MOX_LOG_EXCHANGE = 'mox.log'
-MOX_OBJECT_EXCHANGE = 'mox.rest'
+# Environ wrapper
+env = os.environ.get
 
-IS_LOG_AUTHENTICATION_ENABLED = False
+# System settings
+AMQP_SERVER = env('MOX_AMQP_HOST', 'localhost')
 
-OIOREST_SERVER = "https://referencedata.dk"
+# Agent settings
+MOX_ADVIS_QUEUE = env('MOX_ADVIS_QUEUE', 'Advis')
+MOX_LOG_EXCHANGE = env('MOX_LOG_EXCHANGE', 'mox.log')
+MOX_OBJECT_EXCHANGE = env('MOX_OBJECT_EXCHANGE', 'mox.rest')
+
+IS_LOG_AUTHENTICATION_ENABLED = env('MOX_LOG_AUTHENTICATION_ENABLED', False)
+
+OIOREST_SERVER = env('MOX_OIO_REST_URI', 'https://localhost')
 
 # Public key of SAML IDP
-SAML_IDP_CERTIFICATE = os.path.join(DIR, 'test_auth_data/idp-certificate.pem')
+TEST_PUBLIC_KEY = os.path.join(DIR, 'test_auth_data/idp-certificate.pem')
+SAML_IDP_CERTIFICATE = env('MOX_SAML_IDP_CERTIFICATE', TEST_PUBLIC_KEY)
 
 # Default system email
-FROM_EMAIL = 'mox-advis@noreply.magenta.dk'
+FROM_EMAIL = env('MOX_EMAIL_REPLY_ADDRESS', 'mox-advis@noreply.magenta.dk')
 ADVIS_SUBJECT_PREFIX = '[MOX-ADVIS]'
 
 # Log files
-MOX_ADVIS_LOG_FILE = '/var/log/mox/mox-advis.log'
-MOX_ELK_LOG_FILE = '/var/log/mox/mox-elk.log'
-DO_LOG_TO_AMQP = True
+MOX_ADVIS_LOG_FILE = env('MOX_ADVIS_LOG_FILE', '/var/log/mox/mox-advis.log')
+MOX_ELK_LOG_FILE = env('MOX_ELK_LOG_FILE', '/var/log/mox/mox-elk.log')
+DO_LOG_TO_AMQP = env('MOX_ENABLE_LOG_TO_AMQP', True)

--- a/python_agents/settings.py
+++ b/python_agents/settings.py
@@ -21,10 +21,6 @@ IS_LOG_AUTHENTICATION_ENABLED = env('MOX_LOG_AUTHENTICATION_ENABLED', False)
 
 OIOREST_SERVER = env('MOX_OIO_REST_URI', 'https://localhost')
 
-# Public key of SAML IDP
-TEST_PUBLIC_KEY = os.path.join(DIR, 'test_auth_data/idp-certificate.pem')
-SAML_IDP_CERTIFICATE = env('MOX_SAML_IDP_CERTIFICATE', TEST_PUBLIC_KEY)
-
 # Default system email
 FROM_EMAIL = env('MOX_EMAIL_REPLY_ADDRESS', 'mox-advis@noreply.magenta.dk')
 ADVIS_SUBJECT_PREFIX = '[MOX-ADVIS]'
@@ -33,3 +29,11 @@ ADVIS_SUBJECT_PREFIX = '[MOX-ADVIS]'
 MOX_ADVIS_LOG_FILE = env('MOX_ADVIS_LOG_FILE', '/var/log/mox/mox-advis.log')
 MOX_ELK_LOG_FILE = env('MOX_ELK_LOG_FILE', '/var/log/mox/mox-elk.log')
 DO_LOG_TO_AMQP = env('MOX_ENABLE_LOG_TO_AMQP', True)
+
+# Saml settings
+SAML_IDP_ENTITY_ID = env('MOX_SAML_IDP_ENTITY_ID', 'localhost')
+SAML_MOX_ENTITY_ID = env('MOX_SAML_MOX_ENTITY_ID', 'https://localhost')
+
+# Legacy
+TEST_PUBLIC_KEY = os.path.join(DIR, 'test_auth_data/idp-certificate.pem')
+SAML_IDP_CERTIFICATE = env('MOX_SAML_IDP_CERTIFICATE', TEST_PUBLIC_KEY)

--- a/python_agents/setup/readme.txt
+++ b/python_agents/setup/readme.txt
@@ -1,0 +1,2 @@
+FOR DEVELOPMENT ONLY
+Wrapper shell scripts used by development install.

--- a/python_agents/test_auth_data/readme.txt
+++ b/python_agents/test_auth_data/readme.txt
@@ -1,0 +1,2 @@
+Public key and assertion templates for (legacy) previous SAML IDP implementation.
+This should be updated once a new implementation is in place.


### PR DESCRIPTION
Python agents seperation from OIO rest package (except saml2.py dependency).
Legacy agents excluded from installation.
Documentation (status & todo) added.