### PR TITLE
 db: fix database generation

### DIFF
--- a/oio_rest/oio_rest/db_helpers.py
+++ b/oio_rest/oio_rest/db_helpers.py
@@ -74,7 +74,7 @@ def get_state_names(class_name):
     states = db_struct[class_name.lower()]['tilstande']
 
     if isinstance(states, list):
-        return states[::2]
+        return [state[0] for state in states]
     else:
         return list(states)
 

--- a/oio_rest/oio_rest/db_structure.py
+++ b/oio_rest/oio_rest/db_structure.py
@@ -241,10 +241,8 @@ DATABASE_STRUCTURE = {
                 "brugervendtnoegle", "beskrivelse"]
         },
         "tilstande": [
-            "status",
-            ["Inaktiv", "Aktiv"],
-            "publiceret",
-            ["Publiceret", "IkkePubliceret", "Normal"]
+            ["status", ["Inaktiv", "Aktiv"]],
+            ["publiceret", ["Publiceret", "IkkePubliceret", "Normal"]],
         ],
         "relationer_nul_til_en": ["tilstandsobjekt", "tilstandstype"],
         "relationer_nul_til_mange": [
@@ -268,10 +266,8 @@ DATABASE_STRUCTURE = {
             }
         },
         "tilstande": [
-            "status",
-            ["Inaktiv", "Aktiv", "Aflyst"],
-            "publiceret",
-            ["Publiceret", "IkkePubliceret", "Normal"],
+            ["status", ["Inaktiv", "Aktiv", "Aflyst"]],
+            ["publiceret", ["Publiceret", "IkkePubliceret", "Normal"]],
         ],
         "relationer_nul_til_en": ["aktivitetstype", "emne", "foelsomhedklasse",
                                   "ansvarligklasse", "rekvirentklasse",
@@ -298,12 +294,10 @@ DATABASE_STRUCTURE = {
             }
         },
         "tilstande": [
-            "publiceret",
-            ["Publiceret", "IkkePubliceret", "Normal"],
-            "fremdrift",
-            [
+            ["publiceret", ["Publiceret", "IkkePubliceret", "Normal"]],
+            ["fremdrift", [
                 "Uoplyst", "Visiteret", "Disponeret", "Leveret", "Vurderet"
-            ]
+            ]],
         ],
         "relationer_nul_til_en": ["indsatsmodtager", "indsatstype"],
         "relationer_nul_til_mange": [

--- a/oio_rest/oio_rest/db_structure.py
+++ b/oio_rest/oio_rest/db_structure.py
@@ -241,8 +241,8 @@ DATABASE_STRUCTURE = {
                 "brugervendtnoegle", "beskrivelse"]
         },
         "tilstande": [
-            ["status", ["Inaktiv", "Aktiv"]],
-            ["publiceret", ["Publiceret", "IkkePubliceret", "Normal"]],
+            ("status", ["Inaktiv", "Aktiv"]),
+            ("publiceret", ["Publiceret", "IkkePubliceret", "Normal"]),
         ],
         "relationer_nul_til_en": ["tilstandsobjekt", "tilstandstype"],
         "relationer_nul_til_mange": [
@@ -266,8 +266,8 @@ DATABASE_STRUCTURE = {
             }
         },
         "tilstande": [
-            ["status", ["Inaktiv", "Aktiv", "Aflyst"]],
-            ["publiceret", ["Publiceret", "IkkePubliceret", "Normal"]],
+            ("status", ["Inaktiv", "Aktiv", "Aflyst"]),
+            ("publiceret", ["Publiceret", "IkkePubliceret", "Normal"]),
         ],
         "relationer_nul_til_en": ["aktivitetstype", "emne", "foelsomhedklasse",
                                   "ansvarligklasse", "rekvirentklasse",
@@ -294,10 +294,10 @@ DATABASE_STRUCTURE = {
             }
         },
         "tilstande": [
-            ["publiceret", ["Publiceret", "IkkePubliceret", "Normal"]],
-            ["fremdrift", [
+            ("publiceret", ["Publiceret", "IkkePubliceret", "Normal"]),
+            ("fremdrift", [
                 "Uoplyst", "Visiteret", "Disponeret", "Leveret", "Vurderet"
-            ]],
+            ]),
         ],
         "relationer_nul_til_en": ["indsatsmodtager", "indsatstype"],
         "relationer_nul_til_mange": [

--- a/oio_rest/tests/test_db_helpers.py
+++ b/oio_rest/tests/test_db_helpers.py
@@ -297,16 +297,14 @@ class TestDBHelpers(TestCase):
         with patch('oio_rest.db_helpers.db_struct', new={
             'testclass1': {
                 'tilstande': [
-                    'testtilstand1',
-                    [
+                    ('testtilstand1', [
                         'value1',
                         'value2'
-                    ],
-                    'testtilstand2',
-                    [
+                    ]),
+                    ('testtilstand2', [
                         'value3',
                         'value4'
-                    ]
+                    ]),
                 ],
             },
         }):


### PR DESCRIPTION
I accidentally broke database generation with my Python 3.x
preparations. I did this by opting for a layout for states, which no
longer allowed simple instantiation as a dictionary. Instead, we
switch to a list of two-tuples.