### PR TITLE
fix jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
 
         timeout(2) {
           ansiColor('xterm') {
-            sh 'make -C doc dirhtml'
+            sh 'make -C doc dirhtml SPHINXOPTS=--color'
           }
         }
 
@@ -25,8 +25,6 @@ pipeline {
     }
     stage('Test') {
       steps {
-        echo 'Testing oio_rest...'
-
         timeout(15) {
           ansiColor('xterm') {
             sh 'oio_rest/run_tests.sh'

--- a/doc/sphinx-build.sh
+++ b/doc/sphinx-build.sh
@@ -6,5 +6,6 @@ DIR="$(cd $(dirname $0; pwd))"
 VENV="$DIR/venv"
 
 python3 -m venv venv
-./venv/bin/pip -q install sphinx
-exec ./venv/bin/sphinx-build "$@"
+
+./venv/bin/python -m pip -q install sphinx
+exec ./venv/bin/python -m sphinx.cmd.build "$@"


### PR DESCRIPTION
We can't build the documentation first, as it assumes that we have
virtual environment available.