### PR TITLE
fix installer

### DIFF
--- a/oio_rest/install.py
+++ b/oio_rest/install.py
@@ -33,8 +33,8 @@ sudo('install', '-d', '-o', 'mox', '-g', 'mox',
 
 virtualenv = VirtualEnv()
 
-print "Running setup.py"
-virtualenv.run(DIR + "/setup.py", "develop")
+print "Installing OIO REST into virtual environment"
+virtualenv.run("-m", "pip", "install", "--system", "-e", DIR)
 virtualenv.add_moxlib_pointer()
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
For some reason or other, `xmlsec` wound up being installed in the
home directory of the user invoking the installer. This is probably
related to the horrible hacks Debian and Ubuntu apply to Python's
`distutils`.

Instead, we use `pip` and pass it the Debian-specific `--system`
argument.