### PR TITLE
#22658 — minor fixes & optimisations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ oio_rest/oio_api
 *~
 .ropeproject
 oio_rest/dist
+oio_rest/build
 *.idea/
 *.iml
 **/target/

--- a/db/initdb.sh
+++ b/db/initdb.sh
@@ -4,6 +4,16 @@ set -b
 MOXDIR=${BASE_DIR}
 DIR=${DB_DIR}
 
+test -z "$DIR" && DIR=$(cd $(dirname $0); pwd)
+test -z "$BASE_DIR" && BASE_DIR=$(cd $(dirname $DIR); pwd)
+test -z "$PYTHON_EXEC" && PYTHON_EXEC=${BASE_DIR}/python-env/bin/python
+test -z "$SUPER_USER" && SUPER_USER=postgres
+test -z "$MOX_DB" && MOX_DB=mox
+test -z "$MOX_DB_USER" && MOX_DB_USER=mox
+test -z "$MOX_DB_PASSWORD" && MOX_DB_PASSWORD=mox
+
+cd $DIR
+
 PYTHON=${PYTHON_EXEC}
 
 export PGPASSWORD="$MOX_DB_PASSWORD"
@@ -17,10 +27,13 @@ sudo -u postgres psql -c "GRANT ALL ON DATABASE $MOX_DB TO $MOX_DB_USER"
 sudo -u postgres psql -d $MOX_DB -f basis/dbserver_prep.sql
 
 # Setup AMQP server settings
-sudo -u $SUPER_USER psql -d $MOX_DB -c "insert into amqp.broker
+if test -n "$MOX_AMQP_HOST"
+then
+    sudo -u $SUPER_USER psql -d $MOX_DB -c "insert into amqp.broker
 (host, port, vhost, username, password)
 values ('$MOX_AMQP_HOST', $MOX_AMQP_PORT, '$MOX_AMQP_VHOST', '$MOX_AMQP_USER',
 '$MOX_AMQP_PASS');"
+fi
 
 # Grant mox user privileges to publish to AMQP
 sudo -u $SUPER_USER psql -d $MOX_DB -c "GRANT ALL PRIVILEGES ON SCHEMA amqp TO $MOX_DB_USER;

--- a/oio_rest/oio_rest/app.py
+++ b/oio_rest/oio_rest/app.py
@@ -14,6 +14,7 @@ from . import sag, indsats, dokument, tilstand, aktivitet, organisation
 from . import log, klassifikation
 from .authentication import get_authenticated_user
 from .log_client import log_service_call
+from . import db
 
 from .custom_exceptions import OIOFlaskException, AuthorizationFailedException
 from .custom_exceptions import BadRequestException
@@ -42,6 +43,8 @@ class RegexConverter(BaseConverter):
 
 
 app.url_map.converters['regex'] = RegexConverter
+
+app.teardown_request(db.close_connection)
 
 klassifikation.KlassifikationsHierarki.setup_api(
     base_url=settings.BASE_URL, flask=app,

--- a/oio_rest/oio_rest/db.py
+++ b/oio_rest/oio_rest/db.py
@@ -11,11 +11,12 @@ from psycopg2.pool import ThreadedConnectionPool
 from jinja2 import Environment, FileSystemLoader
 from dateutil import parser as date_parser
 
-from .db_helpers import get_attribute_fields, get_attribute_names
-from .db_helpers import get_field_type, get_state_names, get_relation_field_type
-from .db_helpers import (Soegeord, OffentlighedUndtaget, JournalNotat,
-                        JournalDokument, DokumentVariantType, AktoerAttr,
-                        VaerdiRelationAttr)
+from .db_helpers import (
+    get_attribute_fields, get_attribute_names, get_field_type,
+    get_state_names, get_relation_field_type, Soegeord, OffentlighedUndtaget,
+    JournalNotat, JournalDokument, DokumentVariantType, AktoerAttr,
+    VaerdiRelationAttr,
+)
 
 from .authentication import get_authenticated_user
 

--- a/oio_rest/oio_rest/db.py
+++ b/oio_rest/oio_rest/db.py
@@ -1,6 +1,6 @@
+import datetime
+import enum
 import os
-from enum import Enum
-from datetime import datetime, timedelta
 
 import psycopg2
 import flask
@@ -111,7 +111,9 @@ def convert_attr_value(attribute_name, attribute_field_name,
                 attribute_field_value.get('alternativtitel', None),
                 attribute_field_value.get('hjemmel', None))
     elif field_type == "date":
-        return datetime.strptime(attribute_field_value, "%Y-%m-%d").date()
+        return datetime.datetime.strptime(
+            attribute_field_value, "%Y-%m-%d",
+        ).date()
     elif field_type == "timestamptz":
         return date_parser.parse(attribute_field_value)
     elif field_type == "interval(0)":
@@ -199,7 +201,7 @@ def convert_variants(variants):
     return [DokumentVariantType.input(variant) for variant in variants]
 
 
-class Livscyklus(Enum):
+class Livscyklus(enum.Enum):
     OPSTAAET = 'Opstaaet'
     IMPORTERET = 'Importeret'
     PASSIVERET = 'Passiveret'
@@ -808,8 +810,8 @@ def search_objects(class_name, uuid, registration,
 
 
 def get_life_cycle_code(class_name, uuid):
-    n = datetime.now()
-    n1 = n + timedelta(seconds=1)
+    n = datetime.datetime.now()
+    n1 = n + datetime.timedelta(seconds=1)
     regs = list_objects(class_name, [uuid], n, n1, None, None)
     reg = regs[0][0]
     livscykluskode = reg['registreringer'][0]['livscykluskode']

--- a/oio_rest/oio_rest/db_helpers.py
+++ b/oio_rest/oio_rest/db_helpers.py
@@ -88,10 +88,10 @@ def get_relation_names(class_name):
     "Return the list of all recognized relations for this class."
     if len(_relation_names) == 0:
         for c in db_struct:
-            _relation_names[c] = [
-                a for a in db_struct[c]['relationer_nul_til_en'] +
-                [b for b in db_struct[c]['relationer_nul_til_mange']]
-            ]
+            _relation_names[c] = (
+                db_struct[c]['relationer_nul_til_en'] +
+                db_struct[c]['relationer_nul_til_mange']
+            )
     return _relation_names[class_name.lower()]
 
 

--- a/oio_rest/oio_rest/utils/test_support.py
+++ b/oio_rest/oio_rest/utils/test_support.py
@@ -1,0 +1,164 @@
+#
+# Copyright (c) 2017-2018, Magenta ApS
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+
+import os
+import subprocess
+import sys
+import tempfile
+
+import click
+import mock
+import testing.postgresql
+import psycopg2.pool
+import pytest
+
+from .. import app
+
+import settings
+
+BASE_DIR = os.path.dirname(settings.__file__)
+TOP_DIR = os.path.dirname(BASE_DIR)
+
+
+def initdb(psql):
+    dsn = psql.dsn()
+
+    env = os.environ.copy()
+
+    env.update(
+        TESTING='1',
+        PYTHON=sys.executable,
+        MOX_DB=settings.DATABASE,
+        MOX_DB_USER=settings.DB_USER,
+        MOX_DB_PASSWORD=settings.DB_PASSWORD,
+    )
+
+    with psycopg2.connect(**dsn) as conn:
+        conn.autocommit = True
+
+        with conn.cursor() as curs:
+            curs.execute(
+                "CREATE USER {} WITH SUPERUSER PASSWORD %s".format(
+                    settings.DB_USER,
+                ),
+                (
+                    settings.DB_PASSWORD,
+                ),
+            )
+
+            curs.execute(
+                "CREATE DATABASE {} WITH OWNER = %s".format(settings.DATABASE),
+                (
+                    settings.DB_USER,
+                ),
+            )
+
+    dsn = dsn.copy()
+    dsn['database'] = settings.DATABASE
+    dsn['user'] = settings.DB_USER
+    dsn['password'] = settings.DB_PASSWORD
+
+    mkdb_path = os.path.join(BASE_DIR, '..', 'db', 'mkdb.sh')
+
+    with psycopg2.connect(**dsn) as conn, conn.cursor() as curs:
+        curs.execute(subprocess.check_output([mkdb_path], env=env))
+
+
+@pytest.mark.slow
+class TestCaseMixin(object):
+
+    '''Base class for LoRA test cases with database access.
+    '''
+
+    maxDiff = None
+
+    def get_lora_app(self):
+        app.app.config['DEBUG'] = False
+        app.app.config['TESTING'] = True
+        app.app.config['LIVESERVER_PORT'] = 0
+        app.app.config['PRESERVE_CONTEXT_ON_EXCEPTION'] = False
+
+        return app.app
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestCaseMixin, cls).setUpClass()
+
+        cls.psql_factory = testing.postgresql.PostgresqlFactory(
+            cache_initialized_db=True,
+            on_initialized=initdb
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.psql_factory.clear_cache()
+
+        super(TestCaseMixin, cls).tearDownClass()
+
+    def setUp(self):
+        super(TestCaseMixin, self).setUp()
+
+        self.psql = self.psql_factory()
+        self.psql.wait_booting()
+
+        dsn = self.psql.dsn()
+
+        self.patches = [
+            mock.patch('settings.LOG_AMQP_SERVER', None),
+            mock.patch('settings.DB_HOST', dsn['host'],
+                       create=True),
+            mock.patch('settings.DB_PORT', dsn['port'],
+                       create=True),
+            mock.patch(
+                'oio_rest.db.pool',
+                psycopg2.pool.SimpleConnectionPool(
+                    1, 1,
+                    database=settings.DATABASE,
+                    user=settings.DB_USER,
+                    password=settings.DB_PASSWORD,
+                    host=dsn['host'],
+                    port=dsn['port'],
+                ),
+            ),
+        ]
+
+        for p in self.patches:
+            p.start()
+            self.addCleanup(p.stop)
+
+    def tearDown(self):
+        super(TestCaseMixin, self).tearDown()
+
+        self.psql.stop()
+
+
+@click.command()
+@click.option('-p', '--port', type=int, default=5000)
+def run_with_db(**kwargs):
+    with testing.postgresql.Postgresql(
+        base_dir=tempfile.mkdtemp(prefix='mox'),
+        postgres_args=(
+            '-h localhost -F '
+            '-c logging_collector=off '
+            '-c synchronous_commit=off '
+            '-c fsync=off'
+        ),
+    ) as psql:
+        # We take over the process, given that this is a CLI command.
+        # Hence, there's no need to restore these variables afterwards
+        settings.LOG_AMQP_SERVER = None
+        settings.DB_HOST = psql.dsn()['host']
+        settings.DB_PORT = psql.dsn()['port']
+
+        initdb(psql)
+
+        app.app.run(**kwargs)
+
+
+if __name__ == '__main__':
+    run_with_db()

--- a/oio_rest/oio_rest/utils/test_support.py
+++ b/oio_rest/oio_rest/utils/test_support.py
@@ -101,7 +101,7 @@ class TestCaseMixin(object):
 
         dsn = psql.dsn()
 
-        self.patches = [
+        patches = [
             mock.patch('settings.LOG_AMQP_SERVER', None),
             mock.patch('settings.DB_HOST', dsn['host'],
                        create=True),
@@ -120,14 +120,12 @@ class TestCaseMixin(object):
             ),
         ]
 
-        for p in self.patches:
+        for p in patches:
             p.start()
             self.addCleanup(p.stop)
 
-    def tearDown(self):
-        super(TestCaseMixin, self).tearDown()
+        self.addCleanup(psql.stop)
 
-        self.psql.stop()
 
 
 @click.command()

--- a/oio_rest/oio_rest/utils/test_support.py
+++ b/oio_rest/oio_rest/utils/test_support.py
@@ -24,57 +24,51 @@ import settings
 
 BASE_DIR = os.path.dirname(settings.__file__)
 TOP_DIR = os.path.dirname(BASE_DIR)
+TEMP_DIR = os.path.join(BASE_DIR, 'build', 'tmp')
+
+os.makedirs(TEMP_DIR, exist_ok=True)
+
+psql = testing.postgresql.Postgresql(
+    base_dir=tempfile.mkdtemp(prefix='mox-db-', dir=TEMP_DIR),
+)
+
+atexit.register(psql.stop)
 
 
-def _initdb(psql):
-    dsn = psql.dsn()
+def _initdb():
+    env = {
+        **os.environ,
+        'TESTING': '1',
+        'PYTHON': sys.executable,
+        'MOX_DB': settings.DATABASE,
+        'MOX_DB_USER': settings.DB_USER,
+        'MOX_DB_PASSWORD': settings.DB_PASSWORD,
+    }
 
-    env = os.environ.copy()
-
-    env.update(
-        TESTING='1',
-        PYTHON=sys.executable,
-        MOX_DB=settings.DATABASE,
-        MOX_DB_USER=settings.DB_USER,
-        MOX_DB_PASSWORD=settings.DB_PASSWORD,
-    )
-
-    with psycopg2.connect(**dsn) as conn:
+    with psycopg2.connect(psql.url()) as conn:
         conn.autocommit = True
 
         with conn.cursor() as curs:
-            curs.execute(
-                "CREATE USER {} WITH SUPERUSER PASSWORD %s".format(
-                    settings.DB_USER,
-                ),
-                (
-                    settings.DB_PASSWORD,
-                ),
-            )
+            curs.execute('CREATE USER {} WITH SUPERUSER PASSWORD {!r}'.format(
+                settings.DB_USER, settings.DB_PASSWORD,
+            ))
 
-            curs.execute(
-                "CREATE DATABASE {} WITH OWNER = %s".format(settings.DATABASE),
-                (
-                    settings.DB_USER,
-                ),
-            )
-
-    dsn = dsn.copy()
-    dsn['database'] = settings.DATABASE
-    dsn['user'] = settings.DB_USER
-    dsn['password'] = settings.DB_PASSWORD
+            curs.execute('CREATE DATABASE {} WITH OWNER = {!r}'.format(
+                settings.DATABASE, settings.DB_PASSWORD,
+            ))
 
     mkdb_path = os.path.join(BASE_DIR, '..', 'db', 'mkdb.sh')
+    sql = subprocess.check_output([mkdb_path], env=env)
 
-    with psycopg2.connect(**dsn) as conn, conn.cursor() as curs:
-        curs.execute(subprocess.check_output([mkdb_path], env=env))
+    with psycopg2.connect(psql.url(
+            database=settings.DATABASE,
+            user=settings.DB_USER,
+            password=settings.DB_PASSWORD,
+    )) as conn:
+        conn.autocommit = True
 
-
-psql_factory = testing.postgresql.PostgresqlFactory(
-    cache_initialized_db=True,
-    on_initialized=_initdb
-)
-atexit.register(psql_factory.clear_cache)
+        with conn.cursor() as curs:
+            curs.execute(sql)
 
 
 @pytest.mark.slow
@@ -84,6 +78,7 @@ class TestCaseMixin(object):
     '''
 
     maxDiff = None
+    psql = None
 
     def get_lora_app(self):
         app.app.config['DEBUG'] = False
@@ -93,19 +88,45 @@ class TestCaseMixin(object):
 
         return app.app
 
+    def __reset_db(self):
+        with psycopg2.connect(self.db_url) as conn:
+            conn.autocommit = True
+
+            with conn.cursor() as curs:
+                from oio_common.db_structure import DATABASE_STRUCTURE
+
+                try:
+                    curs.execute("TRUNCATE TABLE {} CASCADE".format(
+                        ', '.join(sorted(DATABASE_STRUCTURE)),
+                    ))
+                except psycopg2.ProgrammingError:
+                    pass
+
     def setUp(self):
         super(TestCaseMixin, self).setUp()
 
-        psql = psql_factory()
-        psql.wait_booting()
+        self.db_url = psql.url(
+            database=settings.DATABASE,
+            user=settings.DB_USER,
+            password=settings.DB_PASSWORD,
+        )
 
-        dsn = psql.dsn()
+        try:
+            with psycopg2.connect(self.db_url) as conn:
+                pass
+        except psycopg2.DatabaseError:
+            _initdb()
 
-        patches = [
+        self.addCleanup(self.__reset_db)
+
+        db_host = psql.dsn()['host']
+        db_port = psql.dsn()['port']
+
+        for p in [
             mock.patch('settings.LOG_AMQP_SERVER', None),
-            mock.patch('settings.DB_HOST', dsn['host'],
+            mock.patch('settings.DB_HOST', db_host,
                        create=True),
-            mock.patch('settings.DB_PORT', dsn['port'],
+            mock.patch('settings.DB_PORT', db_port,
                        create=True),
             mock.patch(
                 'oio_rest.db.pool',
@@ -114,39 +135,51 @@ class TestCaseMixin(object):
                     database=settings.DATABASE,
                     user=settings.DB_USER,
                     password=settings.DB_PASSWORD,
-                    host=dsn['host'],
-                    port=dsn['port'],
+                    host=db_host,
+                    port=db_port,
                 ),
             ),
-        ]
-
-        for p in patches:
+        ]:
             p.start()
             self.addCleanup(p.stop)
 
-        self.addCleanup(psql.stop)
-
-
 
 @click.command()
-@click.option('-p', '--port', type=int, default=5000)
+@click.option('--host', '-h', default='::1',
+              help='The interface to bind to.')
+@click.option('--port', '-p', default=5000,
+              help='The port to bind to.')
+@click.option('use_reloader', '--reload/--no-reload', default=None,
+              help='Enable or disable the reloader.  By default the reloader '
+              'is active if debug is enabled.')
+@click.option('use_debugger', '--debugger/--no-debugger', default=None,
+              help='Enable or disable the debugger.  By default the debugger '
+              'is active if debug is enabled.')
+@click.option('use_reloader', '--eager-loading/--lazy-loader', default=None,
+              help='Enable or disable eager loading.  By default eager '
+              'loading is enabled if the reloader is disabled.')
+@click.option('threaded', '--with-threads/--without-threads', default=True,
+              help='Enable or disable multithreading.')
 def run_with_db(**kwargs):
-    with testing.postgresql.Postgresql(
-        base_dir=tempfile.mkdtemp(prefix='mox'),
-        postgres_args=(
-            '-h localhost -F '
-            '-c logging_collector=off '
-            '-c synchronous_commit=off '
-            '-c fsync=off'
-        ),
-    ) as psql:
+    from oio_rest import db
+
+    with psql:
+        dsn = psql.dsn()
+
         # We take over the process, given that this is a CLI command.
         # Hence, there's no need to restore these variables afterwards
         settings.LOG_AMQP_SERVER = None
-        settings.DB_HOST = psql.dsn()['host']
-        settings.DB_PORT = psql.dsn()['port']
+        settings.DB_HOST = dsn['host']
+        settings.DB_PORT = dsn['port']
 
-        _initdb(psql)
+        db.pool = psycopg2.pool.PersistentConnectionPool(
+            1, 100,
+            database=dsn['database'],
+            user=dsn['user'],
+            password=dsn.get('password'),
+            host=dsn['host'],
+            port=dsn['port'],
+        )
 
         app.app.run(**kwargs)
 

--- a/oio_rest/requirements.txt
+++ b/oio_rest/requirements.txt
@@ -5,7 +5,7 @@ Jinja2==2.10
 MarkupSafe==1.0
 Werkzeug==0.14.1
 itsdangerous==0.24
-psycopg2-binary==2.7.4
+psycopg2cffi-compat
 python3-saml==1.4.0
 pexpect==4.4.0
 python-dateutil==2.7.0

--- a/oio_rest/settings.py
+++ b/oio_rest/settings.py
@@ -11,6 +11,12 @@ DATABASE = getenv('DB_NAME', 'mox')
 DB_USER = getenv('DB_USER', 'mox')
 DB_PASSWORD = getenv('DB_PASS', 'mox')
 
+# Per-process limits on the amount of database connections. Setting
+# the minimum to a non-zero value ensures that the webapp opens this
+# amount at load, failing if the database isn't available.
+DB_MIN_CONNECTIONS = int(getenv('DB_MIN_CONNECTIONS', '0'))
+DB_MAX_CONNECTIONS = int(getenv('DB_MAX_CONNECTIONS', '10'))
+
 # This is where file uploads are stored. It must be readable and writable by
 # the mox user, running the REST API server. This is used in the Dokument
 # hierarchy.

--- a/oio_rest/tests/test_db.py
+++ b/oio_rest/tests/test_db.py
@@ -2,58 +2,18 @@ import collections
 import datetime
 import unittest
 
+import flask_testing
 from mock import MagicMock, call, patch
 
 from oio_rest import db
+from oio_rest import app
 from oio_rest.custom_exceptions import (BadRequestException, DBException,
                                         NotFoundException)
 
 
-class TestDB(unittest.TestCase):
-    @patch('oio_rest.db.psycopg2')
-    def test_get_connection(self, mock):
-        # Arrange
-        mock.connect = MagicMock()
-
-        database = "database"
-        user = "user"
-        password = "password"
-
-        expected_args = (
-            (),
-            {
-                'database': database,
-                'user': user,
-                'password': password,
-                'host': 'localhost',
-                'port': 5432,
-            },
-        )
-
-        # Act
-        with patch('settings.DATABASE', new=database), \
-                patch('settings.DB_USER', new=user), \
-                patch('settings.DB_PASSWORD', new=password):
-
-            db.get_connection()
-
-        # Assert
-        self.assertEqual(expected_args, mock.connect.call_args)
-
-    @patch('oio_rest.db.str', new=MagicMock())
-    @patch('oio_rest.db.psyco_adapt', new=MagicMock())
-    @patch('oio_rest.db.get_connection')
-    def test_adapt_only_creates_one_connection(self, mock_get_conn):
-        # type: (MagicMock) -> None
-        # Arrange
-
-        # Act
-        db.adapt('')
-        db.adapt('')
-        db.adapt('')
-
-        # Assert
-        self.assertEqual(1, mock_get_conn.call_count)
+class TestDB(flask_testing.TestCase):
+    def create_app(self):
+        return app.app
 
     @patch('oio_rest.db.get_relation_field_type')
     def test_convert_relation_value_default(self, mock_get_rel):
@@ -1298,7 +1258,6 @@ class TestPGErrors(unittest.TestCase):
         # Act
         with self.assertRaises(DBException):
             db.create_or_import_object('', '', '', '')
-
 
     @patch("oio_rest.db.psycopg2.Error", new=TestException)
     @patch('oio_rest.db.object_exists', new=lambda *x: False)

--- a/oio_rest/tests/test_integration_class.py
+++ b/oio_rest/tests/test_integration_class.py
@@ -408,3 +408,46 @@ class Tests(util.TestCase):
             method='POST',
             json=data,
         )
+
+    def test_lowercase_state(self):
+        objid = self.load_fixture('/klassifikation/klasse',
+                                  'klasse_opret.json')
+
+        self.assertRequestFails(
+            '/klassifikation/klasse/' + objid,
+            400,
+            method='PATCH',
+            json={
+                'tilstande': {
+                    'publiceret': [
+                        {
+                            "publiceret": "publiceret",
+                            "virkning": {
+                                "from": "2015-01-01",
+                                "to": "2016-01-01",
+                                "notetekst": "odd case!"
+                            },
+                        },
+                    ],
+                },
+            })
+
+        self.assertRequestFails(
+            '/klassifikation/klasse/' + objid,
+            400,
+            method='PATCH',
+            json={
+                'tilstande': {
+                    'publiceret': [
+                        {
+                            "publiceret": "iKKEpUBLICERET",
+                            "virkning": {
+                                "from": "2016-01-01",
+                                "to": "2017-01-01",
+                                "notetekst": "lowercase!"
+                            }
+                        }
+                    ]
+                }
+            },
+        )

--- a/oio_rest/tests/util.py
+++ b/oio_rest/tests/util.py
@@ -10,21 +10,11 @@
 import json
 import os
 import pprint
-import subprocess
-import sys
-import tempfile
 import uuid
 
-import click
 import flask_testing
-import mock
-import testing.postgresql
-import psycopg2.pool
-import pytest
 
-from oio_rest import app
-
-import settings
+from oio_rest.utils import test_support
 
 TESTS_DIR = os.path.dirname(__file__)
 BASE_DIR = os.path.dirname(TESTS_DIR)
@@ -43,116 +33,9 @@ def get_fixture(fixture_name, mode='rt'):
             return fp.read()
 
 
-def initdb(psql):
-    dsn = psql.dsn()
-
-    env = os.environ.copy()
-
-    env.update(
-        TESTING='1',
-        PYTHON=sys.executable,
-        MOX_DB=settings.DATABASE,
-        MOX_DB_USER=settings.DB_USER,
-        MOX_DB_PASSWORD=settings.DB_PASSWORD,
-    )
-
-    with psycopg2.connect(**dsn) as conn:
-        conn.autocommit = True
-
-        with conn.cursor() as curs:
-            curs.execute(
-                "CREATE USER {} WITH SUPERUSER PASSWORD %s".format(
-                    settings.DB_USER,
-                ),
-                (
-                    settings.DB_PASSWORD,
-                ),
-            )
-
-            curs.execute(
-                "CREATE DATABASE {} WITH OWNER = %s".format(settings.DATABASE),
-                (
-                    settings.DB_USER,
-                ),
-            )
-
-    dsn = dsn.copy()
-    dsn['database'] = settings.DATABASE
-    dsn['user'] = settings.DB_USER
-    dsn['password'] = settings.DB_PASSWORD
-
-    mkdb_path = os.path.join(BASE_DIR, '..', 'db', 'mkdb.sh')
-
-    with psycopg2.connect(**dsn) as conn, conn.cursor() as curs:
-        curs.execute(subprocess.check_output([mkdb_path], env=env))
-
-
-@pytest.mark.slow
-class TestCaseMixin(object):
-
-    '''Base class for LoRA test cases with database access.
-    '''
-
-    maxDiff = None
-
+class TestCase(test_support.TestCaseMixin, flask_testing.TestCase):
     def create_app(self):
-        app.app.config['DEBUG'] = False
-        app.app.config['TESTING'] = True
-        app.app.config['LIVESERVER_PORT'] = 0
-        app.app.config['PRESERVE_CONTEXT_ON_EXCEPTION'] = False
-
-        return app.app
-
-    @classmethod
-    def setUpClass(cls):
-        super(TestCaseMixin, cls).setUpClass()
-
-        cls.psql_factory = testing.postgresql.PostgresqlFactory(
-            cache_initialized_db=True,
-            on_initialized=initdb
-        )
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.psql_factory.clear_cache()
-
-        super(TestCaseMixin, cls).tearDownClass()
-
-    def setUp(self):
-        super(TestCaseMixin, self).setUp()
-
-        self.psql = self.psql_factory()
-        self.psql.wait_booting()
-
-        dsn = self.psql.dsn()
-
-        self.patches = [
-            mock.patch('settings.LOG_AMQP_SERVER', None),
-            mock.patch('settings.DB_HOST', dsn['host'],
-                       create=True),
-            mock.patch('settings.DB_PORT', dsn['port'],
-                       create=True),
-            mock.patch(
-                'oio_rest.db.pool',
-                psycopg2.pool.SimpleConnectionPool(
-                    1, 1,
-                    database=settings.DATABASE,
-                    user=settings.DB_USER,
-                    password=settings.DB_PASSWORD,
-                    host=dsn['host'],
-                    port=dsn['port'],
-                ),
-            ),
-        ]
-
-        for p in self.patches:
-            p.start()
-            self.addCleanup(p.stop)
-
-    def tearDown(self):
-        super(TestCaseMixin, self).tearDown()
-
-        self.psql.stop()
+        return self.get_lora_app()
 
     def assertRequestResponse(self, path, expected, message=None,
                               status_code=None, drop_keys=(), **kwargs):
@@ -371,34 +254,3 @@ class TestCaseMixin(object):
             raise
 
         return objid
-
-
-class TestCase(TestCaseMixin, flask_testing.TestCase):
-    pass
-
-
-@click.command()
-@click.option('-p', '--port', type=int, default=5000)
-def run_with_db(**kwargs):
-    with testing.postgresql.Postgresql(
-        base_dir=tempfile.mkdtemp(prefix='mox'),
-        postgres_args=(
-            '-h localhost -F '
-            '-c logging_collector=off '
-            '-c synchronous_commit=off '
-            '-c fsync=off'
-        ),
-    ) as psql:
-        # We take over the process, given that this is a CLI command.
-        # Hence, there's no need to restore these variables afterwards
-        settings.LOG_AMQP_SERVER = None
-        settings.DB_HOST = psql.dsn()['host']
-        settings.DB_PORT = psql.dsn()['port']
-
-        initdb(psql)
-
-        app.app.run(**kwargs)
-
-
-if __name__ == '__main__':
-    run_with_db()

--- a/oio_rest/tests/util.py
+++ b/oio_rest/tests/util.py
@@ -193,12 +193,12 @@ class TestCaseMixin(object):
 
         try:
             if status_code is None:
-                self.assertLess(r.status_code, 300, status_message)
-                self.assertGreaterEqual(r.status_code, 200, status_message)
+                self.assertOK(r, status_message)
             else:
                 self.assertEqual(r.status_code, status_code, status_message)
 
             self.assertEqual(expected, actual, content_message)
+
         except AssertionError:
             print(path)
             print(r.status_code)
@@ -268,6 +268,12 @@ class TestCaseMixin(object):
             message,
         )
 
+    def assertOK(self, response, message=None):
+        assert 200 <= response.status_code < 300, \
+            message or 'request failed with {}!'.format(
+                response.status,
+            )
+
     def assertUUID(self, s):
         try:
             uuid.UUID(s)
@@ -286,8 +292,8 @@ class TestCaseMixin(object):
 
     def get(self, path, **params):
         r = self.perform_request(path, query_string=params)
-        self.assertLess(r.status_code, 300)
-        self.assertGreaterEqual(r.status_code, 200)
+
+        self.assertOK(r)
 
         d = r.json['results'][0]
 
@@ -303,22 +309,19 @@ class TestCaseMixin(object):
 
     def put(self, path, json):
         r = self.perform_request(path, json=json, method="PUT")
-        self.assertLess(r.status_code, 300)
-        self.assertGreaterEqual(r.status_code, 200)
+        self.assertOK(r)
 
         return r.json['uuid']
 
     def patch(self, path, json):
         r = self.perform_request(path, json=json, method="PATCH")
-        self.assertLess(r.status_code, 300)
-        self.assertGreaterEqual(r.status_code, 200)
+        self.assertOK(r)
 
         return r.json['uuid']
 
     def post(self, path, json):
         r = self.perform_request(path, json=json, method="POST")
-        self.assertLess(r.status_code, 300)
-        self.assertGreaterEqual(r.status_code, 200)
+        self.assertOK(r)
 
         return r.json['uuid']
 

--- a/oio_rest/tests/util.py
+++ b/oio_rest/tests/util.py
@@ -183,7 +183,7 @@ class TestCaseMixin(object):
 
         if not message:
             status_message = 'request {!r} failed with status {}'.format(
-                path, r.status_code,
+                path, r.status,
             )
             content_message = 'request {!r} yielded an expected result'.format(
                 path,
@@ -201,7 +201,7 @@ class TestCaseMixin(object):
 
         except AssertionError:
             print(path)
-            print(r.status_code)
+            print(r.status)
             pprint.pprint(actual)
 
             raise
@@ -355,12 +355,20 @@ class TestCaseMixin(object):
             path, json=get_fixture(fixture_name), method=method,
         )
 
-        assert r, 'write of {!r} to {!r} failed!'.format(fixture_name, path)
+        msg = 'write of {!r} to {!r} failed!'.format(fixture_name, path)
 
-        objid = r.json.get('uuid')
+        try:
+            self.assertOK(r, msg)
 
-        print(r.get_data(as_text=True), path)
-        self.assertTrue(objid)
+            objid = r.json.get('uuid')
+
+            self.assertTrue(objid)
+        except AssertionError:
+            print(path)
+            print(r.status)
+            print(r.get_data(as_text=True))
+
+            raise
 
         return objid
 

--- a/oio_rest/tests/util.py
+++ b/oio_rest/tests/util.py
@@ -19,11 +19,11 @@ import click
 import flask_testing
 import mock
 import testing.postgresql
-import psycopg2
+import psycopg2.pool
 import pytest
 
 from oio_rest import app
-from oio_rest import db
+
 import settings
 
 TESTS_DIR = os.path.dirname(__file__)
@@ -132,14 +132,22 @@ class TestCaseMixin(object):
                        create=True),
             mock.patch('settings.DB_PORT', dsn['port'],
                        create=True),
+            mock.patch(
+                'oio_rest.db.pool',
+                psycopg2.pool.SimpleConnectionPool(
+                    1, 1,
+                    database=settings.DATABASE,
+                    user=settings.DB_USER,
+                    password=settings.DB_PASSWORD,
+                    host=dsn['host'],
+                    port=dsn['port'],
+                ),
+            ),
         ]
 
         for p in self.patches:
             p.start()
             self.addCleanup(p.stop)
-
-        if hasattr(db.adapt, 'connection'):
-            del db.adapt.connection
 
     def tearDown(self):
         super(TestCaseMixin, self).tearDown()


### PR DESCRIPTION
This series of commits contains changes that ease running LoRA — and
OIO REST in particular — in development mode. In particular, it allows
running `initdb.sh` without specifying any environment variables and
without restarting Gunicorn.

With these changes, I can do:

```ShellSession
$ python3.5 -m venv python-env
$ ./python-env/bin/pip install -q -e oio_rest -r oio_rest/requirements-test.txt gunicorn
$ dropdb --if-exists mox
$ dropuser --if-exists mox
$ db/initdb.sh
Password:
ALTER ROLE
GRANT
CREATE EXTENSION
CREATE EXTENSION
CREATE EXTENSION
CREATE EXTENSION
CREATE EXTENSION
GRANT
WARNING:  amqp can't find broker 1
 exchange_declare 
------------------
 f
(1 row)

CREATE SCHEMA
ALTER DATABASE
ALTER DATABASE
ALTER DATABASE
[snip]
$ LOG_AMQP_SERVER='' AUDIT_LOG_FILE='' python-env/bin/gunicorn \
> --pythonpath=oio_rest --threads=4 --reload --access-logfile - oio_rest.app:app
[2018-05-15 17:26:48 +0200] [67069] [INFO] Starting gunicorn 19.8.1
[2018-05-15 17:26:48 +0200] [67069] [INFO] Listening at: http://127.0.0.1:8000 (67069)
[2018-05-15 17:26:48 +0200] [67069] [INFO] Using worker: threads
[2018-05-15 17:26:48 +0200] [67072] [INFO] Booting worker with pid: 67072
```

In addition, it moves the support for running a LoRA server within the test suite to the `oio_rest` package so that we can easily re-use it from `mora` without relying on LoRA internals or duplicating the code.