### PR TITLE
#22658 installer tweaks

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,8 @@
 # DOES NOT AUTOMATICALLY INSTALL THE FOLLOWING COMPONENTS:
 # Mox Rest Frontend, Mox Advis, Mox Elk log
 
+set -e
+
 ## Check if executed as root
 if [ $( whoami ) == "root" ]; then
     echo "Do not run as root. We'll sudo when necessary"

--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,7 @@ fi
 ## Variables
 
 # Base directory (current)
-BASE_DIR=$( pwd )
+BASE_DIR=$(cd $(dirname $0); pwd)
 
 # Setup directory
 INSTALLER_DIR=${BASE_DIR}/installer

--- a/install.sh
+++ b/install.sh
@@ -32,7 +32,7 @@ export VIRTUALENV=${BASE_DIR}/python-env
 export PYTHON_EXEC=${VIRTUALENV}/bin/python
 
 ## Install system dependencies
-sudo apt-get install python3 python3-venv python3-dev gcc
+sudo apt-get -qy install python3 python3-venv python3-dev gcc
 
 ## Create virtual environment
 /usr/bin/env python3 -m venv ${VIRTUALENV}

--- a/installer/base/files/nginx.j2
+++ b/installer/base/files/nginx.j2
@@ -1,0 +1,57 @@
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+
+{% if ssl_certificate and ssl_certificate_key %}
+    # Redirect all HTTP requests to HTTPS with a 301 Moved Permanently response.
+    return 301 https://$host$request_uri;
+
+{% else %}
+    location / {
+        proxy_pass http://unix:{{ socket_path }};
+    }
+{% endif %}
+}
+
+
+server {
+    listen {{ https_port }} ssl http2 default_server;
+    listen [::]:{{ https_port }} ssl http2 default_server;
+
+{% if ssl_certificate and ssl_certificate_key %}
+
+    # from https://mozilla.github.io/server-side-tls/ssl-config-generator/
+
+    # certs sent to the client in SERVER HELLO are concatenated in ssl_certificate
+    ssl_certificate {{ ssl_certificate }};
+    ssl_certificate_key {{ ssl_certificate_key }};
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:SSL:50m;
+    ssl_session_tickets off;
+
+    # modern configuration. tweak to your needs.
+    ssl_protocols TLSv1.2;
+    ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
+    ssl_prefer_server_ciphers on;
+
+    # HSTS (ngx_http_headers_module is required) (15768000 seconds = 6 months)
+    add_header Strict-Transport-Security max-age=15768000;
+
+    # OCSP Stapling ---
+    # fetch OCSP records from URL in ssl_certificate and cache them
+    ssl_stapling on;
+    ssl_stapling_verify on;
+
+    ## verify chain of trust of OCSP response using Root CA and Intermediate certs
+    #ssl_trusted_certificate /path/to/root_CA_cert_plus_intermediates;
+
+    #resolver <IP DNS resolver>;
+
+{% else %}
+    include snippets/snakeoil.conf;
+{% endif %}
+
+    location / {
+        proxy_pass http://unix:{{ socket_path }};
+    }
+}

--- a/installer/base/files/oio_rest.service.j2
+++ b/installer/base/files/oio_rest.service.j2
@@ -1,5 +1,7 @@
 [Unit]
 Description="{{ service_description }}"
+Requires={{ name }}.socket
+After=network.target
 
 [Service]
 Type=simple
@@ -7,6 +9,7 @@ Restart=on-failure
 
 User={{ user }}
 Group={{ group }}
+Environment="GUNICORN_BIND_ADDRESS=/run/{{ name }}.socket"
 
 WorkingDirectory={{ working_directory }}
 ExecStart={{ gunicorn }} -c guniconfig.py wsgi:app

--- a/installer/base/files/oio_rest.service.j2
+++ b/installer/base/files/oio_rest.service.j2
@@ -10,6 +10,7 @@ Restart=on-failure
 User={{ user }}
 Group={{ group }}
 Environment="GUNICORN_BIND_ADDRESS=/run/{{ name }}.socket"
+Environment="DB_MIN_CONNECTIONS=1"
 
 WorkingDirectory={{ working_directory }}
 ExecStart={{ gunicorn }} -c guniconfig.py wsgi:app

--- a/installer/base/files/oio_rest.socket.j2
+++ b/installer/base/files/oio_rest.socket.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description="{{ service_description }}"
+
+[Socket]
+SocketUser={{ user }}
+SocketGroup={{ group }}
+SocketMode=0660
+ListenStream={{ socket_path }}
+
+[Install]
+WantedBy=sockets.target

--- a/installer/base/files/pg_hba.conf.j2
+++ b/installer/base/files/pg_hba.conf.j2
@@ -91,7 +91,7 @@ host    all             all             127.0.0.1/32            md5
 local   all             all                                     md5
 
 # "local" is for Unix domain socket connections only
-#local   all             all                                     peer
+local   all             all                                     peer
 # IPv4 local connections:
 #host    all             all             127.0.0.1/32            md5
 # IPv6 local connections:

--- a/installer/base/tasks/configure_environment.sls
+++ b/installer/base/tasks/configure_environment.sls
@@ -12,6 +12,7 @@ install_system_dependencies:
       - libxmlsec1-dev
       - ca-certificates
       - software-properties-common
+      - nginx
 
       # POSTGRESQL
       - postgresql

--- a/installer/base/tasks/configure_environment.sls
+++ b/installer/base/tasks/configure_environment.sls
@@ -26,6 +26,21 @@ install_system_dependencies:
       - rabbitmq-server
 
 
+create_account_group:
+  group.present:
+    - name: {{ config.group }}
+    - system: True
+
+create_account_user:
+  user.present:
+    - name: {{ config.user }}
+    - gid: {{ config.group }}
+    - groups:
+        - {{ config.group }}
+    - home: {{ config.base_dir }}
+    - system: True
+
+
 create_upload_directory:
   file.directory:
     - name: /var/mox

--- a/installer/base/tasks/install_oio_rest.sls
+++ b/installer/base/tasks/install_oio_rest.sls
@@ -23,11 +23,53 @@ deploy_service_file:
     - mode: 600
     - template: jinja
     - context:
-        service_description: "OIO Rest interface"
+        service_description: "OIO REST web application"
+        name: oio_rest
         user: {{ config.user }}
         group: {{ config.group }}
         working_directory: {{ config.base_dir }}/oio_rest
         gunicorn: {{ config.virtualenv }}/bin/gunicorn
+        socket_path: /run/oio_rest/socket
+
+deploy_socket_file:
+  file.managed:
+    - name: /etc/systemd/system/oio_rest.socket
+    - source: salt://files/oio_rest.socket.j2
+    - user: root
+    - group: root
+    - mode: 600
+    - template: jinja
+    - context:
+        service_description: "OIO REST socket"
+        name: oio_rest
+        user: {{ config.user }}
+        group: www-data
+        socket_path: /run/oio_rest/socket
+
+
+undeploy_ubuntu_nginx_site:
+  file.absent:
+    - name: /etc/nginx/sites-enabled/default
+
+
+deploy_nginx_site:
+  service.running:
+    - name: nginx
+    - enable: True
+    - reload: True
+  file.managed:
+    - name: /etc/nginx/sites-enabled/oio_rest
+    - source: salt://files/nginx.j2
+    - user: root
+    - group: root
+    - mode: 644
+    - template: jinja
+    - context:
+        http_port: {{ config.http_port }}
+        https_port: {{ config.https_port }}
+        ssl_certificate: {{ config.ssl_certificate or '' }}
+        ssl_certificate_key: {{ config.ssl_certificate_key or '' }}
+        socket_path: /run/oio_rest/socket
 
 
 enable_and_reload_oio_rest:

--- a/installer/configure.py
+++ b/installer/configure.py
@@ -60,7 +60,7 @@ mox_config = {
 # grains.setval key value
 set_grains = caller.cmd("grains.setval", "mox_config", mox_config)
 
-formatted = json.dumps(set_grains, indent=2)
+formatted = json.dumps(set_grains, indent=2, sort_keys=True)
 
 print("""
 Set grain/system values for the installation process

--- a/installer/configure.py
+++ b/installer/configure.py
@@ -19,10 +19,8 @@ base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 hostname = gethostname()
 
 # User details
-uid = os.getuid()
-gid = os.getgid()
-user = pwd.getpwuid(uid).pw_name
-group = grp.getgrgid(gid).gr_name
+user = 'mox'
+group = 'mox'
 
 # Virtual environment and python executable
 virtualenv = getenv("VIRTUALENV")

--- a/installer/configure.py
+++ b/installer/configure.py
@@ -13,7 +13,7 @@ from client import caller
 #TODO: Run state to check and verify system current state
 
 # Base dir / root of git repository
-base_dir = os.getcwd()
+base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # Hostname
 hostname = gethostname()

--- a/installer/configure.py
+++ b/installer/configure.py
@@ -53,7 +53,11 @@ mox_config = {
     "virtualenv": virtualenv,
     "python_exec": python_exec,
     "db": db_config,
-    "amqp": amqp_config
+    "amqp": amqp_config,
+    "http_port": 80,
+    "https_port": 443,
+    "ssl_certificate": None,
+    "ssl_certificate_key": None,
 }
 
 # Set grains (configuration)


### PR DESCRIPTION
* Add an `nginx` instance to the default install, bind `gunicorn` to a socket rather than a port, and add rudimentary support for configuring SSL in `nginx`.
* Suppress a prompt from `apt-get` during the installation.
* Fix installer logging, and sort the keys in the grain output.
* Set the minimum amount of database connections for a slight speedup of imports, etc.
* Run gunicorn under the `mox` user rather than whomever happens to run the installer.