### PR TITLE
#23725 duplicates with limit and sorting

### DIFF
--- a/db/db-templating/generated-files/_as_sorted_itsystem.sql
+++ b/db/db-templating/generated-files/_as_sorted_itsystem.sql
@@ -12,6 +12,8 @@ NOTICE: This file is auto-generated using the script: apply-template.py itsystem
 
 CREATE OR REPLACE FUNCTION _as_sorted_itsystem(
         itsystem_uuids uuid[],
+        virkningSoeg TSTZRANGE,
+        registreringObj ItsystemRegistreringType,
 	    firstResult int,
 	    maxResults int
         )
@@ -19,15 +21,25 @@ CREATE OR REPLACE FUNCTION _as_sorted_itsystem(
   $$
   DECLARE
           itsystem_sorted_uuid uuid[];
+          registreringSoeg TSTZRANGE;
   BEGIN
 
+IF registreringObj IS NULL OR (registreringObj.registrering).timePeriod IS NULL THEN
+   registreringSoeg = TSTZRANGE(current_timestamp, current_timestamp, '[]');
+ELSE
+    registreringSoeg = (registreringObj.registrering).timePeriod;
+END IF;
+
 itsystem_sorted_uuid:=array(
-SELECT b.itsystem_id
-    FROM  itsystem_registrering b
-    JOIN (SELECT DISTINCT ON (itsystem_registrering_id) itsystem_registrering_id, id, brugervendtnoegle FROM itsystem_attr_egenskaber) a ON a.itsystem_registrering_id=b.id    
-    WHERE b.itsystem_id = ANY (itsystem_uuids)
-    ORDER BY a.brugervendtnoegle
-         LIMIT maxResults OFFSET firstResult
+       SELECT b.itsystem_id
+       FROM itsystem_registrering b
+       JOIN itsystem_attr_egenskaber a ON a.itsystem_registrering_id=b.id
+       WHERE b.itsystem_id = ANY (itsystem_uuids)
+             AND (b.registrering).timeperiod && registreringSoeg
+             AND (a.virkning).timePeriod && virkningSoeg
+       GROUP BY b.itsystem_id
+       ORDER BY array_agg(DISTINCT a.brugervendtnoegle), b.itsystem_id
+       LIMIT maxResults OFFSET firstResult
 );
 
 RETURN itsystem_sorted_uuid;

--- a/db/db-templating/generated-files/_as_sorted_organisationenhed.sql
+++ b/db/db-templating/generated-files/_as_sorted_organisationenhed.sql
@@ -12,6 +12,8 @@ NOTICE: This file is auto-generated using the script: apply-template.py organisa
 
 CREATE OR REPLACE FUNCTION _as_sorted_organisationenhed(
         organisationenhed_uuids uuid[],
+        virkningSoeg TSTZRANGE,
+        registreringObj OrganisationenhedRegistreringType,
 	    firstResult int,
 	    maxResults int
         )
@@ -19,15 +21,25 @@ CREATE OR REPLACE FUNCTION _as_sorted_organisationenhed(
   $$
   DECLARE
           organisationenhed_sorted_uuid uuid[];
+          registreringSoeg TSTZRANGE;
   BEGIN
 
+IF registreringObj IS NULL OR (registreringObj.registrering).timePeriod IS NULL THEN
+   registreringSoeg = TSTZRANGE(current_timestamp, current_timestamp, '[]');
+ELSE
+    registreringSoeg = (registreringObj.registrering).timePeriod;
+END IF;
+
 organisationenhed_sorted_uuid:=array(
-SELECT b.organisationenhed_id
-    FROM  organisationenhed_registrering b
-    JOIN (SELECT DISTINCT ON (organisationenhed_registrering_id) organisationenhed_registrering_id, id, brugervendtnoegle FROM organisationenhed_attr_egenskaber) a ON a.organisationenhed_registrering_id=b.id    
-    WHERE b.organisationenhed_id = ANY (organisationenhed_uuids)
-    ORDER BY a.brugervendtnoegle
-         LIMIT maxResults OFFSET firstResult
+       SELECT b.organisationenhed_id
+       FROM organisationenhed_registrering b
+       JOIN organisationenhed_attr_egenskaber a ON a.organisationenhed_registrering_id=b.id
+       WHERE b.organisationenhed_id = ANY (organisationenhed_uuids)
+             AND (b.registrering).timeperiod && registreringSoeg
+             AND (a.virkning).timePeriod && virkningSoeg
+       GROUP BY b.organisationenhed_id
+       ORDER BY array_agg(DISTINCT a.brugervendtnoegle), b.organisationenhed_id
+       LIMIT maxResults OFFSET firstResult
 );
 
 RETURN organisationenhed_sorted_uuid;

--- a/db/db-templating/generated-files/as_search_aktivitet.sql
+++ b/db/db-templating/generated-files/as_search_aktivitet.sql
@@ -1557,7 +1557,7 @@ END IF;
 auth_filtered_uuids:=_as_filter_unauth_aktivitet(aktivitet_candidates,auth_criteria_arr); 
 /*********************/
 IF firstResult > 0 or maxResults < 2147483647 THEN
-   auth_filtered_uuids = _as_sorted_aktivitet(auth_filtered_uuids, firstResult, maxResults);
+   auth_filtered_uuids = _as_sorted_aktivitet(auth_filtered_uuids, virkningSoeg, registreringObj, firstResult, maxResults);
 END IF;
 return auth_filtered_uuids;
 

--- a/db/db-templating/generated-files/as_search_bruger.sql
+++ b/db/db-templating/generated-files/as_search_bruger.sql
@@ -997,7 +997,7 @@ END IF;
 auth_filtered_uuids:=_as_filter_unauth_bruger(bruger_candidates,auth_criteria_arr); 
 /*********************/
 IF firstResult > 0 or maxResults < 2147483647 THEN
-   auth_filtered_uuids = _as_sorted_bruger(auth_filtered_uuids, firstResult, maxResults);
+   auth_filtered_uuids = _as_sorted_bruger(auth_filtered_uuids, virkningSoeg, registreringObj, firstResult, maxResults);
 END IF;
 return auth_filtered_uuids;
 

--- a/db/db-templating/generated-files/as_search_dokument.sql
+++ b/db/db-templating/generated-files/as_search_dokument.sql
@@ -1628,7 +1628,7 @@ END IF;
 auth_filtered_uuids:=_as_filter_unauth_dokument(dokument_candidates,auth_criteria_arr); 
 /*********************/
 IF firstResult > 0 or maxResults < 2147483647 THEN
-   auth_filtered_uuids = _as_sorted_dokument(auth_filtered_uuids, firstResult, maxResults);
+   auth_filtered_uuids = _as_sorted_dokument(auth_filtered_uuids, virkningSoeg, registreringObj, firstResult, maxResults);
 END IF;
 return auth_filtered_uuids;
 

--- a/db/db-templating/generated-files/as_search_facet.sql
+++ b/db/db-templating/generated-files/as_search_facet.sql
@@ -1025,7 +1025,7 @@ END IF;
 auth_filtered_uuids:=_as_filter_unauth_facet(facet_candidates,auth_criteria_arr); 
 /*********************/
 IF firstResult > 0 or maxResults < 2147483647 THEN
-   auth_filtered_uuids = _as_sorted_facet(auth_filtered_uuids, firstResult, maxResults);
+   auth_filtered_uuids = _as_sorted_facet(auth_filtered_uuids, virkningSoeg, registreringObj, firstResult, maxResults);
 END IF;
 return auth_filtered_uuids;
 

--- a/db/db-templating/generated-files/as_search_indsats.sql
+++ b/db/db-templating/generated-files/as_search_indsats.sql
@@ -1460,7 +1460,7 @@ END IF;
 auth_filtered_uuids:=_as_filter_unauth_indsats(indsats_candidates,auth_criteria_arr); 
 /*********************/
 IF firstResult > 0 or maxResults < 2147483647 THEN
-   auth_filtered_uuids = _as_sorted_indsats(auth_filtered_uuids, firstResult, maxResults);
+   auth_filtered_uuids = _as_sorted_indsats(auth_filtered_uuids, virkningSoeg, registreringObj, firstResult, maxResults);
 END IF;
 return auth_filtered_uuids;
 

--- a/db/db-templating/generated-files/as_search_interessefaellesskab.sql
+++ b/db/db-templating/generated-files/as_search_interessefaellesskab.sql
@@ -997,7 +997,7 @@ END IF;
 auth_filtered_uuids:=_as_filter_unauth_interessefaellesskab(interessefaellesskab_candidates,auth_criteria_arr); 
 /*********************/
 IF firstResult > 0 or maxResults < 2147483647 THEN
-   auth_filtered_uuids = _as_sorted_interessefaellesskab(auth_filtered_uuids, firstResult, maxResults);
+   auth_filtered_uuids = _as_sorted_interessefaellesskab(auth_filtered_uuids, virkningSoeg, registreringObj, firstResult, maxResults);
 END IF;
 return auth_filtered_uuids;
 

--- a/db/db-templating/generated-files/as_search_itsystem.sql
+++ b/db/db-templating/generated-files/as_search_itsystem.sql
@@ -1004,7 +1004,7 @@ END IF;
 auth_filtered_uuids:=_as_filter_unauth_itsystem(itsystem_candidates,auth_criteria_arr); 
 /*********************/
 IF firstResult > 0 or maxResults < 2147483647 THEN
-   auth_filtered_uuids = _as_sorted_itsystem(auth_filtered_uuids, firstResult, maxResults);
+   auth_filtered_uuids = _as_sorted_itsystem(auth_filtered_uuids, virkningSoeg, registreringObj, firstResult, maxResults);
 END IF;
 return auth_filtered_uuids;
 

--- a/db/db-templating/generated-files/as_search_klasse.sql
+++ b/db/db-templating/generated-files/as_search_klasse.sql
@@ -1088,7 +1088,7 @@ END IF;
 auth_filtered_uuids:=_as_filter_unauth_klasse(klasse_candidates,auth_criteria_arr); 
 /*********************/
 IF firstResult > 0 or maxResults < 2147483647 THEN
-   auth_filtered_uuids = _as_sorted_klasse(auth_filtered_uuids, firstResult, maxResults);
+   auth_filtered_uuids = _as_sorted_klasse(auth_filtered_uuids, virkningSoeg, registreringObj, firstResult, maxResults);
 END IF;
 return auth_filtered_uuids;
 

--- a/db/db-templating/generated-files/as_search_klassifikation.sql
+++ b/db/db-templating/generated-files/as_search_klassifikation.sql
@@ -1004,7 +1004,7 @@ END IF;
 auth_filtered_uuids:=_as_filter_unauth_klassifikation(klassifikation_candidates,auth_criteria_arr); 
 /*********************/
 IF firstResult > 0 or maxResults < 2147483647 THEN
-   auth_filtered_uuids = _as_sorted_klassifikation(auth_filtered_uuids, firstResult, maxResults);
+   auth_filtered_uuids = _as_sorted_klassifikation(auth_filtered_uuids, virkningSoeg, registreringObj, firstResult, maxResults);
 END IF;
 return auth_filtered_uuids;
 

--- a/db/db-templating/generated-files/as_search_loghaendelse.sql
+++ b/db/db-templating/generated-files/as_search_loghaendelse.sql
@@ -1032,7 +1032,7 @@ END IF;
 auth_filtered_uuids:=_as_filter_unauth_loghaendelse(loghaendelse_candidates,auth_criteria_arr); 
 /*********************/
 IF firstResult > 0 or maxResults < 2147483647 THEN
-   auth_filtered_uuids = _as_sorted_loghaendelse(auth_filtered_uuids, firstResult, maxResults);
+   auth_filtered_uuids = _as_sorted_loghaendelse(auth_filtered_uuids, virkningSoeg, registreringObj, firstResult, maxResults);
 END IF;
 return auth_filtered_uuids;
 

--- a/db/db-templating/generated-files/as_search_organisation.sql
+++ b/db/db-templating/generated-files/as_search_organisation.sql
@@ -990,7 +990,7 @@ END IF;
 auth_filtered_uuids:=_as_filter_unauth_organisation(organisation_candidates,auth_criteria_arr); 
 /*********************/
 IF firstResult > 0 or maxResults < 2147483647 THEN
-   auth_filtered_uuids = _as_sorted_organisation(auth_filtered_uuids, firstResult, maxResults);
+   auth_filtered_uuids = _as_sorted_organisation(auth_filtered_uuids, virkningSoeg, registreringObj, firstResult, maxResults);
 END IF;
 return auth_filtered_uuids;
 

--- a/db/db-templating/generated-files/as_search_organisationenhed.sql
+++ b/db/db-templating/generated-files/as_search_organisationenhed.sql
@@ -990,7 +990,7 @@ END IF;
 auth_filtered_uuids:=_as_filter_unauth_organisationenhed(organisationenhed_candidates,auth_criteria_arr); 
 /*********************/
 IF firstResult > 0 or maxResults < 2147483647 THEN
-   auth_filtered_uuids = _as_sorted_organisationenhed(auth_filtered_uuids, firstResult, maxResults);
+   auth_filtered_uuids = _as_sorted_organisationenhed(auth_filtered_uuids, virkningSoeg, registreringObj, firstResult, maxResults);
 END IF;
 return auth_filtered_uuids;
 

--- a/db/db-templating/generated-files/as_search_organisationfunktion.sql
+++ b/db/db-templating/generated-files/as_search_organisationfunktion.sql
@@ -990,7 +990,7 @@ END IF;
 auth_filtered_uuids:=_as_filter_unauth_organisationfunktion(organisationfunktion_candidates,auth_criteria_arr); 
 /*********************/
 IF firstResult > 0 or maxResults < 2147483647 THEN
-   auth_filtered_uuids = _as_sorted_organisationfunktion(auth_filtered_uuids, firstResult, maxResults);
+   auth_filtered_uuids = _as_sorted_organisationfunktion(auth_filtered_uuids, virkningSoeg, registreringObj, firstResult, maxResults);
 END IF;
 return auth_filtered_uuids;
 

--- a/db/db-templating/generated-files/as_search_sag.sql
+++ b/db/db-templating/generated-files/as_search_sag.sql
@@ -1117,7 +1117,7 @@ END IF;
 auth_filtered_uuids:=_as_filter_unauth_sag(sag_candidates,auth_criteria_arr); 
 /*********************/
 IF firstResult > 0 or maxResults < 2147483647 THEN
-   auth_filtered_uuids = _as_sorted_sag(auth_filtered_uuids, firstResult, maxResults);
+   auth_filtered_uuids = _as_sorted_sag(auth_filtered_uuids, virkningSoeg, registreringObj, firstResult, maxResults);
 END IF;
 return auth_filtered_uuids;
 

--- a/db/db-templating/generated-files/as_search_tilstand.sql
+++ b/db/db-templating/generated-files/as_search_tilstand.sql
@@ -1149,7 +1149,7 @@ END IF;
 auth_filtered_uuids:=_as_filter_unauth_tilstand(tilstand_candidates,auth_criteria_arr); 
 /*********************/
 IF firstResult > 0 or maxResults < 2147483647 THEN
-   auth_filtered_uuids = _as_sorted_tilstand(auth_filtered_uuids, firstResult, maxResults);
+   auth_filtered_uuids = _as_sorted_tilstand(auth_filtered_uuids, virkningSoeg, registreringObj, firstResult, maxResults);
 END IF;
 return auth_filtered_uuids;
 

--- a/db/db-templating/templates/as_search.jinja.sql
+++ b/db/db-templating/templates/as_search.jinja.sql
@@ -508,7 +508,7 @@ END IF;
 auth_filtered_uuids:=_as_filter_unauth_{{oio_type}}({{oio_type}}_candidates,auth_criteria_arr); 
 /*********************/
 IF firstResult > 0 or maxResults < 2147483647 THEN
-   auth_filtered_uuids = _as_sorted_{{oio_type}}(auth_filtered_uuids, firstResult, maxResults);
+   auth_filtered_uuids = _as_sorted_{{oio_type}}(auth_filtered_uuids, virkningSoeg, registreringObj, firstResult, maxResults);
 END IF;
 return auth_filtered_uuids;
 

--- a/oio_rest/tests/test_integration_activity.py
+++ b/oio_rest/tests/test_integration_activity.py
@@ -388,7 +388,6 @@ class Tests(util.TestCase):
             expected_nothing,
         )
 
-    @unittest.expectedFailure
     def test_searching_with_limit(self):
         objid = self.load_fixture('/aktivitet/aktivitet',
                                   'aktivitet_opret.json')
@@ -422,7 +421,6 @@ class Tests(util.TestCase):
             },
         )
 
-    @unittest.expectedFailure
     def test_searching_with_limit_after_editing_bvn(self):
         objid = self.load_fixture('/aktivitet/aktivitet',
                                   'aktivitet_opret.json')
@@ -478,7 +476,6 @@ class Tests(util.TestCase):
             },
         )
 
-    @unittest.expectedFailure
     def test_searching_temporal_order(self):
         start_time = datetime.datetime.now()
 


### PR DESCRIPTION
This series adjusts sorting so that it doesn't yield duplicates, takes effect & registration times into account, and scales better. In particular, I measured sorting a search that yields 25k objects, and it takes ~2.3s even when an offset of 20k.