### PR TITLE
Shorter database directory

### DIFF
--- a/oio_rest/oio_rest/contentstore.py
+++ b/oio_rest/oio_rest/contentstore.py
@@ -8,6 +8,7 @@ import time
 
 from settings import FILE_UPLOAD_FOLDER
 
+
 def _mkdir_p(path):
     try:
         os.makedirs(path)

--- a/oio_rest/oio_rest/oio_rest.py
+++ b/oio_rest/oio_rest/oio_rest.py
@@ -497,7 +497,8 @@ class OIORestObject(object):
         # JSON schemas
         flask.add_url_rule(
             '{}/{}'.format(class_url, 'schema'),
-            '_'.join([cls.__name__, 'schema']),cls.get_schema, methods=['GET']
+            '_'.join([cls.__name__, 'schema']),
+            cls.get_schema, methods=['GET']
         )
 
     # Templates which may be overridden on subclass.

--- a/oio_rest/tests/test_integration_activity.py
+++ b/oio_rest/tests/test_integration_activity.py
@@ -8,7 +8,6 @@
 
 import datetime
 import time
-import unittest
 import uuid
 
 from tests import util
@@ -440,19 +439,19 @@ class Tests(util.TestCase):
                 'uuid': objid,
             },
             json={
-	        "note": "Ret BVN",
-		"attributter": {
-			"aktivitetegenskaber": [
-			    {
-			        "brugervendtnoegle": "JOGGINGLØB",
-			        "virkning": {
-				    "from": "2017-01-01 00:00:00",
-				    "to": "infinity",
-			        }
+                "note": "Ret BVN",
+                "attributter": {
+                        "aktivitetegenskaber": [
+                            {
+                                "brugervendtnoegle": "JOGGINGLØB",
+                                "virkning": {
+                                    "from": "2017-01-01 00:00:00",
+                                    "to": "infinity",
+                                }
                             },
                         ],
                 },
-	    },
+            },
             method='PATCH',
         )
 
@@ -477,8 +476,6 @@ class Tests(util.TestCase):
         )
 
     def test_searching_temporal_order(self):
-        start_time = datetime.datetime.now()
-
         objids = [str(uuid.UUID(int=i)) for i in range(3)]
 
         no_time = datetime.datetime.now()
@@ -510,26 +507,26 @@ class Tests(util.TestCase):
                 'uuid': objids[1],
             },
             json={
-	        "note": "Ret BVN",
-		"attributter": {
-			"aktivitetegenskaber": [
-			    {
-			        "brugervendtnoegle": "TESTFÆTTER",
-			        "virkning": {
-				    "from": "2017-01-01 00:00:00",
-				    "to": "infinity",
-			        }
+                "note": "Ret BVN",
+                "attributter": {
+                        "aktivitetegenskaber": [
+                            {
+                                "brugervendtnoegle": "TESTFÆTTER",
+                                "virkning": {
+                                    "from": "2017-01-01 00:00:00",
+                                    "to": "infinity",
+                                }
                             },
-			    {
-			        "brugervendtnoegle": "ABEKAT",
-			        "virkning": {
-				    "from": "2015-01-01 00:00:00",
-				    "to": "2017-01-01 00:00:00",
-			        }
+                            {
+                                "brugervendtnoegle": "ABEKAT",
+                                "virkning": {
+                                    "from": "2015-01-01 00:00:00",
+                                    "to": "2017-01-01 00:00:00",
+                                }
                             },
                         ],
                 },
-	    },
+            },
             method='PATCH',
         )
 

--- a/oio_rest/tests/test_package_metadata.py
+++ b/oio_rest/tests/test_package_metadata.py
@@ -13,6 +13,7 @@ import unittest
 
 from . import util
 
+
 class VersionTest(unittest.TestCase):
     def test_versions(self):
         with open(os.path.join(util.TOP_DIR, 'VERSION')) as fp:


### PR DESCRIPTION
A long branch name broke the MO tests due to the path to the PostgreSQL UNIX socket being too long. This PR shortens it, and cleans the logic a bit.