### PR TITLE
[RFC] add basic support for counting objects

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,7 +66,7 @@ pipeline {
   post {
     always {
       junit healthScaleFactor: 200.0,           \
-        testResults: '**/build/reports/*.xml'
+        testResults: 'oio_rest/TEST-*.xml'
 
       warnings canRunOnFailed: true, consoleParsers: [
         [parserName: 'Sphinx-build'],
@@ -75,6 +75,9 @@ pipeline {
 
       cobertura coberturaReportFile: 'oio_rest/coverage.xml',    \
         maxNumberOfBuilds: 0
+
+      junit healthScaleFactor: 200.0,     \
+        testResults: 'mora/build/reports/*.xml'
 
       cleanWs()
     }

--- a/oio_rest/.coveragerc
+++ b/oio_rest/.coveragerc
@@ -1,0 +1,12 @@
+# -*- conf -*-
+[run]
+branch = True
+source =
+     oio_rest/
+
+[report]
+exclude_lines =
+     raise NotImplementedError
+     if flask.current_app.debug:
+     if settings.PROD_MODE:
+     \bpass\b

--- a/oio_rest/oio_rest/db_helpers.py
+++ b/oio_rest/oio_rest/db_helpers.py
@@ -107,6 +107,7 @@ GENERAL_SEARCH_PARAMS = {
     'uuid',
     'vilkaarligattr',
     'vilkaarligrel',
+    'count',
 }
 
 TEMPORALITY_PARAMS = {

--- a/oio_rest/oio_rest/oio_rest.py
+++ b/oio_rest/oio_rest/oio_rest.py
@@ -236,6 +236,14 @@ class OIORestObject(object):
 
         valid_list_args = TEMPORALITY_PARAMS | {'uuid'}
 
+        if args.get('count') and args['count'] == '1':
+            registration = build_registration(cls.__name__, list_args)
+
+            return jsonify({
+                'results':
+                db.count_objects(cls.__name__.lower(), registration),
+            })
+
         # Assume the search operation if other params were specified
         if not valid_list_args.issuperset(args):
             # Only one uuid is supported through the search operation

--- a/oio_rest/oio_rest/templates/sql/count_objects.sql
+++ b/oio_rest/oio_rest/templates/sql/count_objects.sql
@@ -1,0 +1,78 @@
+SELECT COUNT(DISTINCT Entry)
+FROM {{cls}} as Entry
+  JOIN {{cls}}_registrering Reg
+    ON Reg.{{cls}}_id = Entry.id
+
+{#- For now, we join in the relevant tables once per relation -- that's rather
+    slow, but reliable #}
+{%- for rel_kind in reg['relations'] %}
+  JOIN {{cls}}_relation Rel_{{rel_kind}}
+    ON Rel_{{rel_kind}}.{{cls}}_registrering_id = Reg.id
+{%- endfor %}
+
+{%- for attr_kind in reg['attributes'] %}
+  {%- set attr_kind_short = attr_kind[cls|length:] %}
+  JOIN {{cls}}_attr_{{attr_kind_short}} Prop_{{attr_kind}}
+    ON Prop_{{attr_kind}}.{{cls}}_registrering_id = Reg.id
+{%- endfor %}
+
+{%- for state_kind in reg['states'] %}
+  JOIN {{cls}}_tils_{{state_kind}} State_{{state_kind}}
+    ON State_{{state_kind}}.{{cls}}_registrering_id = Reg.id
+{%- endfor %}
+
+WHERE
+  -- prerequisites
+  (Reg.registrering).livscykluskode <> 'Slettet'::Livscykluskode
+  AND
+  (Reg.registrering).timeperiod @> now()
+  AND
+
+{%- for rel_kind, rel_values in reg['relations'].items() %}
+  -- {{rel_kind}} -> {{rel_value}}
+  Rel_{{rel_kind}}.rel_type = {{cls}}relationkode('{{rel_kind}}')
+  AND
+  (Rel_{{rel_kind}}.virkning).timeperiod @> now()
+  AND
+  {%- for rel_value in rel_values %}
+    {%- if rel_value.objekttype %}
+    Rel_{{rel_kind}}.objekt_type = '{{rel_value.objekttype}}'
+    AND
+    {%- endif %}
+    {%- if rel_value.uuid %}
+    Rel_{{rel_kind}}.rel_maal_uuid = uuid('{{rel_value.uuid}}')
+    AND
+    {%- endif %}
+    {%- if rel_value.urn %}
+    Rel_{{rel_kind}}.rel_maal_urn = '{{rel_value.urn}}'
+    AND
+    {%- endif %}
+  {%- endfor %}
+{%- endfor %}
+
+{%- for attr_kind, attr_values in reg['attributes'].items() %}
+  {%- for prop_value in attr_values %}
+    -- {{attr_kind}} -> {{prop_value}}
+    (Prop_{{attr_kind}}.virkning).timeperiod @> now()
+    AND
+    {%- for k, v in prop_value.items() %}
+    Prop_{{attr_kind}}.{{k}} ILIKE '{{v}}'
+    AND
+    {%- endfor %}
+  {%- endfor %}
+{%- endfor %}
+
+{%- for state_kind, state_values in reg['states'].items() %}
+  {%- for state_value in state_values %}
+    -- {{state_kind}} -> {{state_value}}
+    (State_{{state_kind}}.virkning).timeperiod @> now()
+    AND
+    {%- for k, v in state_value.items() %}
+      State_{{state_kind}}.{{k}} = '{{v}}'
+      AND
+    {%- endfor %}
+  {%- endfor %}
+{%- endfor %}
+
+{#- avoid the need for checking for the last clause #}
+TRUE

--- a/oio_rest/requirements-test.txt
+++ b/oio_rest/requirements-test.txt
@@ -1,8 +1,7 @@
 -r requirements.txt
 Flask-Testing
 testing.postgresql
-pytest
-pytest-cov
+unittest-xml-reporting
 mock
 requests_mock
 coverage

--- a/oio_rest/run_tests.sh
+++ b/oio_rest/run_tests.sh
@@ -28,4 +28,7 @@ export MOX_AMQP_VHOST="/"
 $PYTHON -m pip install -e .
 $PYTHON -m pip install -r requirements-test.txt
 $PYTHON -m flake8 --exit-zero
-$PYTHON -m pytest
+
+$PYTHON -m coverage run -m xmlrunner "$@"
+$PYTHON -m coverage report
+$PYTHON -m coverage xml coverage.xml

--- a/oio_rest/tests/test_integration_counting.py
+++ b/oio_rest/tests/test_integration_counting.py
@@ -1,0 +1,116 @@
+#
+# Copyright (c) 2018, Magenta ApS
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+
+import copy
+import json
+import unittest
+
+from . import util
+
+
+def mkuuid(n: int):
+    return "00000000-0000-0000-0000-{:012d}".format(n)
+
+
+class Tests(util.TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.path = '/organisation/organisation'
+
+    def make_org(self, num: int, valid: bool=True):
+        nums = str(num)
+        effect = {
+            "from": "2000-01-01",
+            "to": "infinity",
+        }
+
+        obj = {
+            "attributter": {
+                "organisationegenskaber": [
+                    {
+                        "brugervendtnoegle": "unit" + nums,
+                        "organisationsnavn": "unit" + nums,
+                        "virkning": effect,
+                    },
+                ],
+            },
+            "relationer": {
+                'ansatte': [
+                    {
+                        "uuid": mkuuid(num),
+                        "virkning": effect,
+                    },
+                    {
+                        "urn": "urn:" + nums,
+                        "virkning": effect,
+                    }
+                ]
+            },
+            "tilstande": {
+                "organisationgyldighed": [
+                    {
+                        "gyldighed": "Aktiv" if valid else "Inaktiv",
+                        "virkning": effect,
+                    },
+                ],
+            },
+        }
+
+        #print(json.dumps(obj, indent=2))
+
+        r = self.perform_request(self.path, json=obj)
+        self.assert201(r)
+
+    def check(self, query_string, n):
+        with self.subTest('{!r} - {}'.format(query_string, n)):
+            r1 = self.perform_request(self.path,
+                                      query_string=query_string)
+            self.assert200(r1)
+
+            r2 = self.perform_request(self.path,
+                                      query_string=query_string + '&count=1')
+            self.assert200(r2)
+
+            self.assertEqual(
+                len(r1.json['results'][0]),
+                r2.json['results'][0],
+            )
+
+            self.assertEqual(n, r2.json['results'][0])
+
+    def test_counting(self):
+        for i in range(0, 50, 5):
+            self.make_org(i, i % 10)
+
+        self.check('bvn=%', 10)
+        self.check('bvn=a%', 0)
+        self.check('bvn=unit%', 10)
+        self.check('bvn=unit1%', 2)
+        self.check('bvn=unit10', 1)
+        self.check('bvn=unit10&organisationsnavn=unit10', 1)
+        self.check('bvn=unit%&organisationsnavn=unit%', 10)
+        self.check('bvn=unit1%&organisationsnavn=unit1%', 2)
+        self.check('bvn=unit1%&organisationsnavn=unit10', 1)
+        self.check('bvn=unit10&organisationsnavn=unit1%', 1)
+        self.check('bvn=unit10&organisationsnavn=unit10', 1)
+        self.check('bvn=unit10&organisationsnavn=unit15', 0)
+
+        self.check('gyldighed=Aktiv', 5)
+
+        self.check('bvn=unit1%&gyldighed=Aktiv', 1)
+
+        self.check('ansatte=00000000-0000-0000-0000-000000000010',
+                   1)
+        self.check('bvn=unit1%&ansatte=00000000-0000-0000-0000-000000000010',
+                   1)
+        self.check('bvn=unit1%&gyldighed=Aktiv&ansatte=urn:15', 1)
+        self.check('bvn=unit1%&gyldighed=Inaktiv&ansatte=urn:15', 0)
+        self.check('bvn=unit1%&ansatte=urn:10', 1)
+        self.check('bvn=unit1%&ansatte=urn:10&ansatte=urn:15', 0)
+        self.check('bvn=unit1%&gyldighed=Aktiv&ansatte=urn:10&ansatte=urn:15', 0)

--- a/oio_rest/tests/test_integration_counting.py
+++ b/oio_rest/tests/test_integration_counting.py
@@ -67,8 +67,8 @@ class Tests(util.TestCase):
         r = self.perform_request(self.path, json=obj)
         self.assert201(r)
 
-    def check(self, query_string, n):
-        with self.subTest('{!r} - {}'.format(query_string, n)):
+    def check(self, query_string, expected):
+        with self.subTest(query_string):
             r1 = self.perform_request(self.path,
                                       query_string=query_string)
             self.assert200(r1)
@@ -77,12 +77,11 @@ class Tests(util.TestCase):
                                       query_string=query_string + '&count=1')
             self.assert200(r2)
 
-            self.assertEqual(
-                len(r1.json['results'][0]),
-                r2.json['results'][0],
-            )
+            actual_search = len(r1.json['results'][0])
+            actual_count = r2.json['results'][0]
 
-            self.assertEqual(n, r2.json['results'][0])
+            self.assertEqual(expected, actual_search)
+            self.assertEqual(actual_search, actual_count)
 
     def test_counting(self):
         for i in range(0, 50, 5):
@@ -102,6 +101,7 @@ class Tests(util.TestCase):
         self.check('bvn=unit10&organisationsnavn=unit15', 0)
 
         self.check('gyldighed=Aktiv', 5)
+        self.check('gyldighed=Aktiv&gyldighed=Inaktiv', 0)
 
         self.check('bvn=unit1%&gyldighed=Aktiv', 1)
 
@@ -113,4 +113,11 @@ class Tests(util.TestCase):
         self.check('bvn=unit1%&gyldighed=Inaktiv&ansatte=urn:15', 0)
         self.check('bvn=unit1%&ansatte=urn:10', 1)
         self.check('bvn=unit1%&ansatte=urn:10&ansatte=urn:15', 0)
-        self.check('bvn=unit1%&gyldighed=Aktiv&ansatte=urn:10&ansatte=urn:15', 0)
+        self.check('bvn=unit1%&gyldighed=Aktiv&ansatte=urn:10&ansatte=urn:15',
+                   0)
+
+        self.check('ansatte=00000000-0000-0000-0000-000000000010&ansatte=urn:10',
+                   1)
+
+        self.check('vilkaarligattr=unit20', 1)
+        self.check('vilkaarligattr=unit2%', 2)

--- a/oio_rest/tests/test_integration_simple.py
+++ b/oio_rest/tests/test_integration_simple.py
@@ -142,11 +142,26 @@ class Tests(util.TestCase):
             endpoints)
 
         for endpoint in endpoints:
-            self.assertRequestResponse(
-                endpoint + '?bvn=%',
-                {
-                    'results': [
-                        [],
-                    ],
-                },
-            )
+            with self.subTest(endpoint):
+                self.assertRequestResponse(
+                    endpoint + '?bvn=%',
+                    {
+                        'results': [
+                            [],
+                        ],
+                    },
+                )
+
+                self.assertRequestResponse(
+                    endpoint + '?count=1&bvn=%',
+                    {
+                        'results': [0],
+                    },
+                )
+
+                self.assertRequestResponse(
+                    endpoint + '?count=1',
+                    {
+                        'results': [0],
+                    },
+                )


### PR DESCRIPTION
This is a quick-and-dirty implementation which is significantly faster in
most cases. The main downside is that it doesn't support restrictions,
yet, and also doesn't consider effect and registration time beyond now.

Posted here for comments and feedback.

Some benchmarks in a database with ~56k objects, all valid with
searches that yield ~800 objects:

- filtering for validity, an attribute and one relation:
  from ~2.7s to <0.1s
- filtering for validity, an attribute and two relations:
  from ~4.8s to ~4.5s

The extra relation happens to be largely redundant in the MO data
model, but the cause of the significant overhead is likely joining the
relations table twice. If we could get rid of that, near-instant
searches seem doable.

The motivation for doing this is that the MO front page took more than 30s
to render with a large™ data set.