### PR TITLE
Updated to use flask_saml_sso for auth flow

### DIFF
--- a/oio_rest/oio_rest/app.py
+++ b/oio_rest/oio_rest/app.py
@@ -20,6 +20,8 @@ from .custom_exceptions import OIOFlaskException, AuthorizationFailedException
 from .custom_exceptions import BadRequestException
 from .auth import tokens
 
+import flask_saml_sso
+
 import settings
 
 app = Flask(__name__)
@@ -56,6 +58,9 @@ dokument.DokumentHierarki.setup_api(base_url=settings.BASE_URL, flask=app)
 aktivitet.AktivitetsHierarki.setup_api(base_url=settings.BASE_URL, flask=app)
 indsats.IndsatsHierarki.setup_api(base_url=settings.BASE_URL, flask=app)
 tilstand.TilstandsHierarki.setup_api(base_url=settings.BASE_URL, flask=app)
+
+app.config.from_object(settings)
+flask_saml_sso.init_app(app)
 
 
 @app.route('/')

--- a/oio_rest/oio_rest/authentication.py
+++ b/oio_rest/oio_rest/authentication.py
@@ -5,6 +5,7 @@ from base64 import b64decode
 from functools import wraps
 
 from flask import request
+import flask_saml_sso
 
 from .custom_exceptions import UnauthorizedException
 from .custom_exceptions import AuthorizationFailedException
@@ -98,6 +99,8 @@ def requires_auth(f):
     def decorated(*args, **kwargs):
         if settings.USE_SAML_AUTHENTICATION:
             check_saml_authentication()
+        elif settings.SAML_AUTH_ENABLE:
+            flask_saml_sso.check_saml_authentication()
         return f(*args, **kwargs)
 
     return decorated

--- a/oio_rest/requirements.txt
+++ b/oio_rest/requirements.txt
@@ -6,9 +6,8 @@ MarkupSafe==1.0
 Werkzeug==0.14.1
 itsdangerous==0.24
 psycopg2cffi-compat==1.1
-python3-saml==1.4.1
 pexpect==4.6.0
 python-dateutil==2.7.3
 pika==0.12.0
 jsonschema==2.6.0
--e git+https://github.com/magenta-aps/flask_saml_sso@development#egg=flask_saml_sso
+-e git+https://github.com/magenta-aps/flask_saml_sso@master#egg=flask_saml_sso

--- a/oio_rest/requirements.txt
+++ b/oio_rest/requirements.txt
@@ -11,3 +11,4 @@ pexpect==4.6.0
 python-dateutil==2.7.3
 pika==0.12.0
 jsonschema==2.6.0
+-e git+https://github.com/magenta-aps/flask_saml_sso@development#egg=flask_saml_sso

--- a/oio_rest/settings.py
+++ b/oio_rest/settings.py
@@ -87,3 +87,21 @@ LOG_IGNORED_SERVICES = ['Log', ]
 
 # Log files
 AUDIT_LOG_FILE = getenv('AUDIT_LOG_FILE', '/var/log/mox/audit.log')
+
+SAML_IDP_METADATA_URL = getenv(
+    'SAML_IDP_METADATA_URL',
+    'https://172.16.20.100/simplesaml/saml2/idp/metadata.php'
+)
+SAML_IDP_INSECURE = getenv('SAML_IDP_INSECURE', False)
+SAML_REQUESTS_SIGNED = getenv('SAML_REQUESTS_SIGNED', False)
+SAML_KEY_FILE = getenv('SAML_KEY_FILE', None)
+SAML_CERT_FILE = getenv('SAML_CERT_FILE', None)
+SAML_AUTH_ENABLE = getenv('SAML_AUTH_ENABLE', False)
+
+SQLALCHEMY_DATABASE_URI = getenv(
+    'SQLALCHEMY_DATABASE_URI',
+    "postgresql://sessions:sessions@127.0.0.1/sessions"
+)
+SESSION_SQLALCHEMY_TABLE = getenv('SESSION_SQLALCHEMY_TABLE', 'sessions')
+SESSION_PERMANENT = getenv('SESSION_PERMANENT', True)
+PERMANENT_SESSION_LIFETIME = getenv('PERMANENT_SESSION_LIFETIME', 3600)

--- a/oio_rest/setup.py
+++ b/oio_rest/setup.py
@@ -10,12 +10,6 @@ basedir = os.path.dirname(__file__)
 with open(os.path.join(basedir, 'VERSION')) as fp:
     version = fp.read().strip()
 
-with open(os.path.join(basedir, 'requirements.txt')) as fp:
-    install_requires = fp.readlines()
-
-with open(os.path.join(basedir, 'requirements-test.txt')) as fp:
-    test_requires = [s for s in fp.readlines() if not s.startswith('-')]
-
 setup(
     name='oio_rest',
     version=version,
@@ -36,15 +30,10 @@ setup(
     },
     include_package_data=True,
     zip_safe=False,
-    install_requires=install_requires,
     entry_points={
         # -*- Entry points: -*-
         'console_scripts': [
             'oio_api = oio_rest.app:app.run',
         ],
     },
-    tests_require=test_requires,
-    extras_require={
-        'tests': test_requires,
-    }
 )


### PR DESCRIPTION
The build currently fails because we currently install `flask_saml_sso` directly from Github with the `-e` flag, which isn't supported in `setup.py`.
The solution to this will be to publish `flask_saml_sso` to PyPI, which will happen once https://github.com/magenta-aps/flask_saml_sso/pull/1 is merged.