### PR TITLE
settings: simplify overriding `DB_STRUCTURES`.

### DIFF
--- a/oio_rest/oio_rest/db_helpers.py
+++ b/oio_rest/oio_rest/db_helpers.py
@@ -7,10 +7,10 @@ from psycopg2._range import DateTimeTZRange
 from psycopg2.extensions import adapt as psyco_adapt, ISQLQuote
 from psycopg2.extensions import register_adapter as psyco_register_adapter
 
-from settings import REAL_DB_STRUCTURE as db_struct
-
 from .contentstore import content_store
 from .custom_exceptions import BadRequestException
+
+import settings
 
 _attribute_fields = {}
 
@@ -22,7 +22,7 @@ def get_attribute_fields(attribute_name):
 
     if not _attribute_fields:
         # Initialize attr fields for ease of use.
-        for c, fs in db_struct.items():
+        for c, fs in settings.REAL_DB_STRUCTURE.items():
             for a, v in fs["attributter"].items():
                 _attribute_fields[c + a] = v + ['virkning']
 
@@ -30,7 +30,7 @@ def get_attribute_fields(attribute_name):
 
 
 def get_field_type(attribute_name, field_name):
-    for c, fs in db_struct.items():
+    for c, fs in settings.REAL_DB_STRUCTURE.items():
         if "attributter_metadata" in fs:
             for a, fs in fs["attributter_metadata"].items():
                 if attribute_name == c + a:
@@ -43,7 +43,7 @@ _attribute_names = {}
 
 
 def get_relation_field_type(class_name, field_name):
-    class_info = db_struct[class_name.lower()]
+    class_info = settings.REAL_DB_STRUCTURE[class_name.lower()]
     if 'relationer_metadata' in class_info:
         metadata = class_info['relationer_metadata']
         for relation in metadata:
@@ -56,7 +56,7 @@ def get_relation_field_type(class_name, field_name):
 def get_attribute_names(class_name):
     "Return the list of all recognized attributes for this class."
     if not _attribute_names:
-        for c, fs in db_struct.items():
+        for c, fs in settings.REAL_DB_STRUCTURE.items():
             # unfortunately, the ordering of attribute names is of
             # semantic importance to the database code, and the
             # ordering isn't consistent in Python 3.5
@@ -72,7 +72,7 @@ _state_names = {}
 
 def get_state_names(class_name):
     "Return the list of all recognized states for this class."
-    states = db_struct[class_name.lower()]['tilstande']
+    states = settings.REAL_DB_STRUCTURE[class_name.lower()]['tilstande']
 
     if isinstance(states, list):
         return [state[0] for state in states]
@@ -86,7 +86,7 @@ _relation_names = {}
 def get_relation_names(class_name):
     "Return the list of all recognized relations for this class."
     if len(_relation_names) == 0:
-        for c, fs in db_struct.items():
+        for c, fs in settings.REAL_DB_STRUCTURE.items():
             _relation_names[c] = (
                 fs['relationer_nul_til_en'] +
                 fs['relationer_nul_til_mange']
@@ -122,7 +122,7 @@ def get_valid_search_parameters(class_name):
     """Return set of all searchable parameters specific to this class"""
     # type: str -> set
     if len(_search_params) == 0:
-        for c in db_struct:
+        for c in settings.REAL_DB_STRUCTURE:
             params = set(
                 a
                 for attr in get_attribute_names(c)

--- a/oio_rest/oio_rest/validate.py
+++ b/oio_rest/oio_rest/validate.py
@@ -427,15 +427,7 @@ def generate_json_schema(obj):
     return schema
 
 
-SCHEMA = {
-    obj: copy.deepcopy(generate_json_schema(obj))
-    for obj in settings.REAL_DB_STRUCTURE.keys()
-}
-
-# Due to an inconsistency between the way LoRa handles
-# "DokumentVariantEgenskaber" and the specs' we will have to do this for now,
-# i.e. we allow any JSON-object for "Dokument"
-SCHEMA['dokument'] = {'type': 'object'}
+SCHEMA = None
 
 
 def validate(input_json):
@@ -445,5 +437,18 @@ def validate(input_json):
     :raise jsonschema.exceptions.ValidationError: If the request JSON is not
     valid according to the JSON schema.
     """
+    global SCHEMA
+
+    if SCHEMA is None:
+        SCHEMA = {
+            obj: copy.deepcopy(generate_json_schema(obj))
+            for obj in settings.REAL_DB_STRUCTURE.keys()
+        }
+
+        # Due to an inconsistency between the way LoRa handles
+        # "DokumentVariantEgenskaber" and the specs' we will have to do this for now,
+        # i.e. we allow any JSON-object for "Dokument"
+        SCHEMA['dokument'] = {'type': 'object'}
+
     obj_type = get_lora_object_type(input_json)
     jsonschema.validate(input_json, SCHEMA[obj_type])

--- a/oio_rest/tests/test_db_helpers.py
+++ b/oio_rest/tests/test_db_helpers.py
@@ -6,6 +6,10 @@ from werkzeug.datastructures import ImmutableMultiDict
 from oio_rest import db_helpers
 from oio_rest.custom_exceptions import BadRequestException
 
+import settings
+
+from . import util
+
 
 class TestDBHelpers(TestCase):
     maxDiff = None
@@ -15,7 +19,7 @@ class TestDBHelpers(TestCase):
         db_helpers._attribute_names = {}
         db_helpers._relation_names = {}
 
-    @patch('oio_rest.db_helpers.db_struct', new={
+    @util.patch_db_struct({
         'testclass1': {
             'attributter': {
                 'testattribut': [
@@ -84,7 +88,7 @@ class TestDBHelpers(TestCase):
         # Assert
         self.assertEqual(expected_result, actual_result)
 
-    @patch('oio_rest.db_helpers.db_struct', new={
+    @util.patch_db_struct({
         'testclass1': {
             'attributter_metadata': {
                 'testattribut': {
@@ -104,7 +108,7 @@ class TestDBHelpers(TestCase):
         # Assert
         self.assertEqual(expected_result, actual_result)
 
-    @patch('oio_rest.db_helpers.db_struct', new={
+    @util.patch_db_struct({
         'testclass1': {
             'attributter_metadata': {
                 'testattribut': {
@@ -124,7 +128,7 @@ class TestDBHelpers(TestCase):
         # Assert
         self.assertEqual(expected_result, actual_result)
 
-    @patch('oio_rest.db_helpers.db_struct')
+    @patch('settings.REAL_DB_STRUCTURE')
     def test_get_relation_field_type_default(self, p):
         # Arrange
         expected_result = 'text'
@@ -136,7 +140,7 @@ class TestDBHelpers(TestCase):
         # Assert
         self.assertEqual(expected_result, actual_result)
 
-    @patch('oio_rest.db_helpers.db_struct', new={
+    @util.patch_db_struct({
         'testclass1': {
             'relationer_metadata': {
                 '*': {
@@ -164,7 +168,7 @@ class TestDBHelpers(TestCase):
         self.assertEqual(expected_result1, actual_result1)
         self.assertEqual(expected_result2, actual_result2)
 
-    @patch('oio_rest.db_helpers.db_struct', new={
+    @util.patch_db_struct({
         'testclass1': {
             'relationer_metadata': {
                 '*': {
@@ -188,7 +192,7 @@ class TestDBHelpers(TestCase):
         # Assert
         self.assertEqual(expected_result, actual_result)
 
-    @patch('oio_rest.db_helpers.db_struct', new={
+    @util.patch_db_struct({
         'testclass1': {
             'attributter': {
                 'testattribut1': [
@@ -266,7 +270,7 @@ class TestDBHelpers(TestCase):
         # Act
         actual_result = {
             c: db_helpers.get_attribute_names(c)
-            for c in db_helpers.db_struct
+            for c in settings.REAL_DB_STRUCTURE
         }
 
         # Assert
@@ -284,7 +288,7 @@ class TestDBHelpers(TestCase):
         self.assertEqual(expected_result, actual_result)
 
     def test_get_state_names(self):
-        with patch('oio_rest.db_helpers.db_struct', new={
+        with util.patch_db_struct({
             'testclass1': {
                 'tilstande': {
                     'testtilstand1': [
@@ -310,7 +314,7 @@ class TestDBHelpers(TestCase):
             # Assert
             self.assertEqual(expected_result, sorted(actual_result))
 
-        with patch('oio_rest.db_helpers.db_struct', new={
+        with util.patch_db_struct({
             'testclass1': {
                 'tilstande': [
                     ('testtilstand1', [
@@ -336,7 +340,7 @@ class TestDBHelpers(TestCase):
             # Assert
             self.assertEqual(expected_result, actual_result)
 
-    @patch('oio_rest.db_helpers.db_struct', new={
+    @util.patch_db_struct({
         'testclass1': {
             'relationer_nul_til_en': [
                 'value1',
@@ -577,7 +581,7 @@ class TestDBHelpers(TestCase):
         # Act
         actual_result = {
             c: db_helpers.get_relation_names(c)
-            for c in db_helpers.db_struct
+            for c in settings.REAL_DB_STRUCTURE
         }
 
         # Assert
@@ -648,7 +652,7 @@ class TestDBHelpers(TestCase):
         # Act
         actual_result = {
             c: list(db_helpers.get_state_names(c))
-            for c in db_helpers.db_struct
+            for c in settings.REAL_DB_STRUCTURE
         }
 
         # Assert
@@ -710,7 +714,7 @@ class TestDBHelpers(TestCase):
         # Act
         actual_result = {
             c: db_helpers.get_state_names(c)
-            for c in db_helpers.db_struct
+            for c in settings.REAL_DB_STRUCTURE
         }
 
         # Assert

--- a/oio_rest/tests/test_oio_rest.py
+++ b/oio_rest/tests/test_oio_rest.py
@@ -15,6 +15,8 @@ from oio_rest.custom_exceptions import (BadRequestException, NotFoundException,
 from oio_rest.oio_rest import OIOStandardHierarchy, OIORestObject
 from oio_rest import oio_rest
 
+from . import util
+
 
 class TestClassRestObject(OIORestObject):
     pass
@@ -312,10 +314,7 @@ class TestOIORestObject(TestCase):
                         "garbage": ["garbage"]}
 
         with self.app.test_request_context(method='GET'), \
-                patch("oio_common.db_structure.REAL_DB_STRUCTURE",
-                      new=db_structure), \
-                patch("settings.REAL_DB_STRUCTURE",
-                      new=db_structure):
+                util.patch_db_struct(db_structure):
 
             # Act
             actual_fields = json.loads(
@@ -338,7 +337,7 @@ class TestOIORestObject(TestCase):
 
     @freezegun.freeze_time('2017-01-01', tz_offset=1)
     @patch('oio_rest.db.list_objects')
-    @patch('oio_rest.db_helpers.db_struct', new=db_struct)
+    @util.patch_db_struct(db_struct)
     def test_get_objects_list_uses_default_params(self,
                                                   mock_list):
         # Arrange
@@ -368,7 +367,7 @@ class TestOIORestObject(TestCase):
         self.assertDictEqual(expected_result, actual_result)
 
     @patch('oio_rest.db.list_objects')
-    @patch('oio_rest.db_helpers.db_struct', new=db_struct)
+    @util.patch_db_struct(db_struct)
     def test_get_objects_list_uses_supplied_params(self, mock):
         # Arrange
         data = ["1", "2", "3"]
@@ -411,7 +410,7 @@ class TestOIORestObject(TestCase):
         self.assertDictEqual(expected_result, actual_result)
 
     @patch('oio_rest.db.list_objects')
-    @patch('oio_rest.db_helpers.db_struct', new=db_struct)
+    @util.patch_db_struct(db_struct)
     def test_get_objects_returns_empty_list_on_no_results(self, mock):
         # Arrange
 
@@ -428,7 +427,7 @@ class TestOIORestObject(TestCase):
         self.assertDictEqual(expected_result, actual_result)
 
     @freezegun.freeze_time('2017-01-01', tz_offset=1)
-    @patch('oio_rest.db_helpers.db_struct', new=db_struct)
+    @util.patch_db_struct(db_struct)
     @patch('oio_rest.oio_rest.build_registration')
     @patch('oio_rest.db.search_objects')
     def test_get_objects_search_uses_default_params(self, mock_search,
@@ -469,7 +468,7 @@ class TestOIORestObject(TestCase):
         self.assertEqual(expected_args, actual_args)
         self.assertDictEqual(expected_result, actual_result)
 
-    @patch('oio_rest.db_helpers.db_struct', new=db_struct)
+    @util.patch_db_struct(db_struct)
     @patch('oio_rest.oio_rest.build_registration')
     @patch('oio_rest.db.search_objects')
     def test_get_objects_search_uses_supplied_params(self, mock_search,
@@ -532,7 +531,7 @@ class TestOIORestObject(TestCase):
         self.assertEqual(expected_args, actual_args)
         self.assertDictEqual(expected_result, actual_result)
 
-    @patch('oio_rest.db_helpers.db_struct', new=db_struct)
+    @util.patch_db_struct(db_struct)
     @patch('oio_rest.utils.build_registration')
     @patch('oio_rest.db.search_objects')
     def test_get_objects_search_raises_exception_on_multi_uuid(
@@ -560,7 +559,7 @@ class TestOIORestObject(TestCase):
                 self.assertRaises(BadRequestException):
             self.testclass.get_objects()
 
-    @patch('oio_rest.db_helpers.db_struct', new=db_struct)
+    @util.patch_db_struct(db_struct)
     @patch('oio_rest.db.search_objects')
     def test_get_objects_search_raises_exception_on_unknown_args(self,
                                                                  mock_search):
@@ -698,7 +697,7 @@ class TestOIORestObject(TestCase):
                 self.assertRaises(GoneException):
             self.testclass.get_object(uuid)
 
-    @patch('oio_rest.db_helpers.db_struct', new=db_struct)
+    @util.patch_db_struct(db_struct)
     @patch('oio_rest.db.list_objects')
     def test_get_object_raises_on_unknown_args(self, mock_list):
         # Arrange
@@ -1068,11 +1067,7 @@ class TestOIOStandardHierarchy(TestCase):
         db_structure = expected_result.copy()
         db_structure.update({"garbage": "1234"})
 
-        with \
-             patch("oio_common.db_structure.REAL_DB_STRUCTURE",
-                   new=db_structure), \
-             patch("settings.REAL_DB_STRUCTURE",
-                   new=db_structure):
+        with util.patch_db_struct(db_structure):
             # Act
             self.testclass.setup_api(base_url="URL", flask=flask)
 

--- a/oio_rest/tests/util.py
+++ b/oio_rest/tests/util.py
@@ -7,9 +7,11 @@
 #
 
 
+import contextlib
 import json
 import os
 import pprint
+import unittest.mock
 import uuid
 
 import flask_testing
@@ -32,6 +34,14 @@ def get_fixture(fixture_name, mode='rt'):
             return json.load(fp)
         else:
             return fp.read()
+
+@contextlib.contextmanager
+def patch_db_struct(new):
+    with \
+         unittest.mock.patch('settings.REAL_DB_STRUCTURE', new=new), \
+         unittest.mock.patch('oio_common.db_structure.REAL_DB_STRUCTURE',
+                             new=new):
+        yield
 
 
 class TestCase(test_support.TestCaseMixin, flask_testing.TestCase):


### PR DESCRIPTION
Every single direct import of `DB_STRUCTURES` and friends needs to be patched when overriding it in tests. So avoid them.