### PR TITLE
#25849 consolidate mocking

### DIFF
--- a/oio_rest/oio_rest/utils/test_support.py
+++ b/oio_rest/oio_rest/utils/test_support.py
@@ -30,6 +30,14 @@ TOP_DIR = os.path.dirname(BASE_DIR)
 DB_DIR = os.path.join(BASE_DIR, 'build', 'db')
 
 
+@contextlib.contextmanager
+def patch_db_struct(new):
+    with \
+         mock.patch('settings.REAL_DB_STRUCTURE', new=new), \
+         mock.patch('oio_common.db_structure.REAL_DB_STRUCTURE', new=new):
+        yield
+
+
 @functools.lru_cache()
 def psql():
     os.makedirs(DB_DIR, exist_ok=True)

--- a/oio_rest/tests/test_db_helpers.py
+++ b/oio_rest/tests/test_db_helpers.py
@@ -5,10 +5,9 @@ from werkzeug.datastructures import ImmutableMultiDict
 
 from oio_rest import db_helpers
 from oio_rest.custom_exceptions import BadRequestException
+from oio_rest.utils import test_support
 
 import settings
-
-from . import util
 
 
 class TestDBHelpers(TestCase):
@@ -19,7 +18,7 @@ class TestDBHelpers(TestCase):
         db_helpers._attribute_names = {}
         db_helpers._relation_names = {}
 
-    @util.patch_db_struct({
+    @test_support.patch_db_struct({
         'testclass1': {
             'attributter': {
                 'testattribut': [
@@ -88,7 +87,7 @@ class TestDBHelpers(TestCase):
         # Assert
         self.assertEqual(expected_result, actual_result)
 
-    @util.patch_db_struct({
+    @test_support.patch_db_struct({
         'testclass1': {
             'attributter_metadata': {
                 'testattribut': {
@@ -108,7 +107,7 @@ class TestDBHelpers(TestCase):
         # Assert
         self.assertEqual(expected_result, actual_result)
 
-    @util.patch_db_struct({
+    @test_support.patch_db_struct({
         'testclass1': {
             'attributter_metadata': {
                 'testattribut': {
@@ -128,8 +127,8 @@ class TestDBHelpers(TestCase):
         # Assert
         self.assertEqual(expected_result, actual_result)
 
-    @patch('settings.REAL_DB_STRUCTURE')
-    def test_get_relation_field_type_default(self, p):
+    @test_support.patch_db_struct(MagicMock())
+    def test_get_relation_field_type_default(self):
         # Arrange
         expected_result = 'text'
 
@@ -140,7 +139,7 @@ class TestDBHelpers(TestCase):
         # Assert
         self.assertEqual(expected_result, actual_result)
 
-    @util.patch_db_struct({
+    @test_support.patch_db_struct({
         'testclass1': {
             'relationer_metadata': {
                 '*': {
@@ -168,7 +167,7 @@ class TestDBHelpers(TestCase):
         self.assertEqual(expected_result1, actual_result1)
         self.assertEqual(expected_result2, actual_result2)
 
-    @util.patch_db_struct({
+    @test_support.patch_db_struct({
         'testclass1': {
             'relationer_metadata': {
                 '*': {
@@ -192,7 +191,7 @@ class TestDBHelpers(TestCase):
         # Assert
         self.assertEqual(expected_result, actual_result)
 
-    @util.patch_db_struct({
+    @test_support.patch_db_struct({
         'testclass1': {
             'attributter': {
                 'testattribut1': [
@@ -288,7 +287,7 @@ class TestDBHelpers(TestCase):
         self.assertEqual(expected_result, actual_result)
 
     def test_get_state_names(self):
-        with util.patch_db_struct({
+        with test_support.patch_db_struct({
             'testclass1': {
                 'tilstande': {
                     'testtilstand1': [
@@ -314,7 +313,7 @@ class TestDBHelpers(TestCase):
             # Assert
             self.assertEqual(expected_result, sorted(actual_result))
 
-        with util.patch_db_struct({
+        with test_support.patch_db_struct({
             'testclass1': {
                 'tilstande': [
                     ('testtilstand1', [
@@ -340,7 +339,7 @@ class TestDBHelpers(TestCase):
             # Assert
             self.assertEqual(expected_result, actual_result)
 
-    @util.patch_db_struct({
+    @test_support.patch_db_struct({
         'testclass1': {
             'relationer_nul_til_en': [
                 'value1',

--- a/oio_rest/tests/test_oio_rest.py
+++ b/oio_rest/tests/test_oio_rest.py
@@ -14,6 +14,7 @@ from oio_rest.custom_exceptions import (BadRequestException, NotFoundException,
                                         GoneException)
 from oio_rest.oio_rest import OIOStandardHierarchy, OIORestObject
 from oio_rest import oio_rest
+from oio_rest.utils import test_support
 
 from . import util
 
@@ -314,7 +315,7 @@ class TestOIORestObject(TestCase):
                         "garbage": ["garbage"]}
 
         with self.app.test_request_context(method='GET'), \
-                util.patch_db_struct(db_structure):
+                test_support.patch_db_struct(db_structure):
 
             # Act
             actual_fields = json.loads(
@@ -337,7 +338,7 @@ class TestOIORestObject(TestCase):
 
     @freezegun.freeze_time('2017-01-01', tz_offset=1)
     @patch('oio_rest.db.list_objects')
-    @util.patch_db_struct(db_struct)
+    @test_support.patch_db_struct(db_struct)
     def test_get_objects_list_uses_default_params(self,
                                                   mock_list):
         # Arrange
@@ -367,7 +368,7 @@ class TestOIORestObject(TestCase):
         self.assertDictEqual(expected_result, actual_result)
 
     @patch('oio_rest.db.list_objects')
-    @util.patch_db_struct(db_struct)
+    @test_support.patch_db_struct(db_struct)
     def test_get_objects_list_uses_supplied_params(self, mock):
         # Arrange
         data = ["1", "2", "3"]
@@ -410,7 +411,7 @@ class TestOIORestObject(TestCase):
         self.assertDictEqual(expected_result, actual_result)
 
     @patch('oio_rest.db.list_objects')
-    @util.patch_db_struct(db_struct)
+    @test_support.patch_db_struct(db_struct)
     def test_get_objects_returns_empty_list_on_no_results(self, mock):
         # Arrange
 
@@ -427,7 +428,7 @@ class TestOIORestObject(TestCase):
         self.assertDictEqual(expected_result, actual_result)
 
     @freezegun.freeze_time('2017-01-01', tz_offset=1)
-    @util.patch_db_struct(db_struct)
+    @test_support.patch_db_struct(db_struct)
     @patch('oio_rest.oio_rest.build_registration')
     @patch('oio_rest.db.search_objects')
     def test_get_objects_search_uses_default_params(self, mock_search,
@@ -468,7 +469,7 @@ class TestOIORestObject(TestCase):
         self.assertEqual(expected_args, actual_args)
         self.assertDictEqual(expected_result, actual_result)
 
-    @util.patch_db_struct(db_struct)
+    @test_support.patch_db_struct(db_struct)
     @patch('oio_rest.oio_rest.build_registration')
     @patch('oio_rest.db.search_objects')
     def test_get_objects_search_uses_supplied_params(self, mock_search,
@@ -531,7 +532,7 @@ class TestOIORestObject(TestCase):
         self.assertEqual(expected_args, actual_args)
         self.assertDictEqual(expected_result, actual_result)
 
-    @util.patch_db_struct(db_struct)
+    @test_support.patch_db_struct(db_struct)
     @patch('oio_rest.utils.build_registration')
     @patch('oio_rest.db.search_objects')
     def test_get_objects_search_raises_exception_on_multi_uuid(
@@ -559,7 +560,7 @@ class TestOIORestObject(TestCase):
                 self.assertRaises(BadRequestException):
             self.testclass.get_objects()
 
-    @util.patch_db_struct(db_struct)
+    @test_support.patch_db_struct(db_struct)
     @patch('oio_rest.db.search_objects')
     def test_get_objects_search_raises_exception_on_unknown_args(self,
                                                                  mock_search):
@@ -697,7 +698,7 @@ class TestOIORestObject(TestCase):
                 self.assertRaises(GoneException):
             self.testclass.get_object(uuid)
 
-    @util.patch_db_struct(db_struct)
+    @test_support.patch_db_struct(db_struct)
     @patch('oio_rest.db.list_objects')
     def test_get_object_raises_on_unknown_args(self, mock_list):
         # Arrange
@@ -1067,7 +1068,7 @@ class TestOIOStandardHierarchy(TestCase):
         db_structure = expected_result.copy()
         db_structure.update({"garbage": "1234"})
 
-        with util.patch_db_struct(db_structure):
+        with test_support.patch_db_struct(db_structure):
             # Act
             self.testclass.setup_api(base_url="URL", flask=flask)
 

--- a/oio_rest/tests/util.py
+++ b/oio_rest/tests/util.py
@@ -7,7 +7,6 @@
 #
 
 
-import contextlib
 import json
 import os
 import pprint
@@ -34,14 +33,6 @@ def get_fixture(fixture_name, mode='rt'):
             return json.load(fp)
         else:
             return fp.read()
-
-@contextlib.contextmanager
-def patch_db_struct(new):
-    with \
-         unittest.mock.patch('settings.REAL_DB_STRUCTURE', new=new), \
-         unittest.mock.patch('oio_common.db_structure.REAL_DB_STRUCTURE',
-                             new=new):
-        yield
 
 
 class TestCase(test_support.TestCaseMixin, flask_testing.TestCase):


### PR DESCRIPTION
This consolidates mocking `db_structures` into the `test_support` module. Without this change, it's rather hard to move it around without breaking the MO tests.