### PR TITLE
Run tests as if the computer was in Copenhagen

### DIFF
--- a/oio_rest/oio_rest/utils/test_support.py
+++ b/oio_rest/oio_rest/utils/test_support.py
@@ -76,6 +76,8 @@ def _initdb():
                 settings.DATABASE, settings.DB_PASSWORD,
             ))
 
+            curs.execute("ALTER DATABASE {} SET time zone 'Europe/Copenhagen'".format(settings.DATABASE))
+
     with psycopg2.connect(psql().url(
         database=settings.DATABASE,
     )) as conn:

--- a/oio_rest/oio_rest/utils/test_support.py
+++ b/oio_rest/oio_rest/utils/test_support.py
@@ -76,6 +76,11 @@ def _initdb():
                 settings.DATABASE, settings.DB_PASSWORD,
             ))
 
+            # The tests are written as if the computer has the local
+            # time zone set to 'Europe/Copenhagen'. This setting
+            # makes postgresql spit out dates in the format the tests
+            # expect. This is not part of the database sql or templates
+            # because we don't want a hardcoded timezone in production.
             curs.execute("ALTER DATABASE {} SET time zone 'Europe/Copenhagen'".format(settings.DATABASE))
 
     with psycopg2.connect(psql().url(

--- a/oio_rest/tests/test_integration_activity.py
+++ b/oio_rest/tests/test_integration_activity.py
@@ -7,6 +7,7 @@
 #
 
 import datetime
+import dateutil
 import time
 import uuid
 
@@ -478,7 +479,8 @@ class Tests(util.TestCase):
     def test_searching_temporal_order(self):
         objids = [str(uuid.UUID(int=i)) for i in range(3)]
 
-        no_time = datetime.datetime.now()
+        tz = dateutil.tz.gettz('Europe/Copenhagen')
+        no_time = datetime.datetime.now(tz).replace(tzinfo=None)
 
         time.sleep(0.01)
 
@@ -497,7 +499,7 @@ class Tests(util.TestCase):
 
         time.sleep(0.01)
 
-        exists_time = datetime.datetime.now()
+        exists_time = datetime.datetime.now(tz).replace(tzinfo=None)
 
         time.sleep(0.01)
 


### PR DESCRIPTION
The tests can now run *everywhere*!

(disclaimer: I only verified that they work in Copenhagen, Danmarkshavn (Grønland) and Mexico)