### PR TITLE
tests: disable fsync in postgres, for speed; move socket to /tmp

### DIFF
--- a/oio_rest/oio_rest/utils/test_support.py
+++ b/oio_rest/oio_rest/utils/test_support.py
@@ -51,6 +51,10 @@ def psql():
 
     psql = testing.postgresql.Postgresql(
         base_dir=DB_DIR,
+        postgres_args=(
+            '-h 127.0.0.1 -F -c logging_collector=off '
+            '-c fsync=off -c unix_socket_directories=/tmp'
+        ),
     )
 
     atexit.register(psql.stop)


### PR DESCRIPTION
The former might cause a speedup, and who cares about resilience in
tests, anyway? The latter should address long branch names.