### PR TITLE
Feature/26061 settings doc

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -82,7 +82,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'venv']
 pygments_style = 'sphinx'
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
-todo_include_todos = False
+todo_include_todos = True
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -35,6 +35,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
     'sphinxcontrib.httpdomain',
+    'sphinx.ext.todo',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -21,6 +21,7 @@ Content
    user/agents.rst
    user/auth.rst
    user/deployment.rst
+   user/settings.rst
 
 .. toctree::
    :maxdepth: 1

--- a/doc/user/auth.rst
+++ b/doc/user/auth.rst
@@ -1,9 +1,15 @@
+.. _auth:
+
 Authentication
 ==============
 
 .. warning::
    
     This document is outdated.
+
+.. todo::
+
+   When updating this as part of #25911. Also update :ref:`auth-settings`.
 
 SAML token authentication is enabled by default. This requires that
 you have access to a SAML Identity Provider (IdP) which provides a

--- a/doc/user/deployment.rst
+++ b/doc/user/deployment.rst
@@ -50,39 +50,3 @@ unix socket, then expose the socket using a HTTP proxy of your own choosing.
 
 More on how to configure in the advanced configuration document. Link:
 ``Document is currently being written``
-
-
-Configuration
--------------
-
-Most configurable parameters of oio_rest can be injected with
-environment variables, alternatively you may set the parameters
-explicitly in the "settings.py" file.
-
-(Please see $ROOT/oio_rest/settings.py)
-
-As mentioned, most parameters are accessible.
-If they are NOT set by you, we have provided sensible fallback values.
-
-Example::
-
-   # settings.py
-
-   # DB (Postgres) settings
-   DATABASE = getenv('DB_NAME', 'mox')
-   DB_USER = getenv('DB_USER', 'mox')
-   DB_PASSWORD = getenv('DB_PASS', 'mox')
-
-
-The oio rest api is served using the wsgi server gunicorn.
-The gunicorn server can be configured through the "guniconfig.py" file.
-
-(Please see $ROOT/oio_rest/guniconfig.py)
-
-Similar to the oio rest settings file,
-gunicorn can be configured using environment variables: ::
-
-   # guniconfig.py
-
-   # Bind address (Can be either TCP or Unix socket)
-   bind = env("GUNICORN_BIND_ADDRESS", '127.0.0.1:8080')

--- a/doc/user/settings.rst
+++ b/doc/user/settings.rst
@@ -3,9 +3,9 @@ Settings
 ========
 
 Most configurable parameters of ``oio_rest`` can be injected with environment
-variables, alternatively you may set the parameters in a file.
+variables. Alternatively you may set the parameters in a file.
 
-Environment variables overwrites default values. The settings file overwrites
+Environment variables overwrites default values. The settings file overwrite
 both default values `and environment variables`.
 
 .. py:data:: CONFIG_FILE
@@ -140,7 +140,7 @@ Authentication
 
       Fix this whole section as part of #25911.
 
-MOX have two independent ways to use SAML. An older one from the file
+LoRa has two independent ways to use SAML. An older one from the file
 :file:`mox/oio_rest/oio_rest/auth/saml2.py` and a newer one from the package
 `flask_saml_sso <https://github.com/magenta-aps/flask_saml_sso>`_. Only use one
 of them at a time. They are both disabled by default. For an overview of how

--- a/doc/user/settings.rst
+++ b/doc/user/settings.rst
@@ -268,16 +268,15 @@ Restrictions
 
 .. todo::
 
-      Fix this section.
-
+       When writing authentication documentation #25911, include a section on
+       restrictions and link to it from here.
 
 .. py:data:: DO_ENABLE_RESTRICTIONS
 
    Default: ``False``
 
-   Whether authorization is enabled. If not, the :data:`AUTH_RESTRICTION_MODULE`
-   is not called.
-
+   Whether authorization is enabled and restrictions can be used. If not, the
+   :data:`AUTH_RESTRICTION_MODULE` is not called.
 
 .. py:data:: AUTH_RESTRICTION_MODULE
 

--- a/doc/user/settings.rst
+++ b/doc/user/settings.rst
@@ -2,10 +2,23 @@
 Settings
 ========
 
+Most configurable parameters of ``oio_rest`` can be injected with environment
+variables, alternatively you may set the parameters in a file.
+
+Environment variables overwrites default values. The settings file overwrites
+both default values `and environment variables`.
 
 .. py:data:: CONFIG_FILE
 
+   Setting the environment variable :data:`CONFIG_FILE` to a a path to a JSON
+   file containing a dict of ``"<setting>": <value>`` pairs will load the
+   settings specified in the file.
+
+   The settings from the file have precedens over any environment variables and
+   will overwrite their values.
+
    Default: ``None``
+
 
 .. py:data:: BASE_URL
 

--- a/doc/user/settings.rst
+++ b/doc/user/settings.rst
@@ -22,10 +22,21 @@ both default values `and environment variables`.
 
 .. py:data:: BASE_URL
 
+   .. todo::
+
+      Fill out this section.
+
    Default: ``""``
 
 
-# Database (PostgreSQL) settings
+Database
+--------
+
+PostgreSQL
+
+.. todo::
+
+      Fill out this section.
 
 .. py:data:: DB_HOST
 
@@ -67,6 +78,12 @@ both default values `and environment variables`.
 
    Default: ``"oio_rest.db.db_structure"``
 
+File upload
+-----------
+
+.. todo::
+
+      Fix this section.
 
 # This is where file uploads are stored. It must be readable and writable by
 # the mox user, running the REST API server. This is used in the Dokument
@@ -76,7 +93,12 @@ both default values `and environment variables`.
 
    Default: ``"/var/mox"``
 
+SAML
+----
 
+.. todo::
+
+      Fix this section.
 
 # The Endpoint specified in the AppliesTo element of the STS request
 # This will be used to verify the Audience of the SAML Assertion
@@ -137,6 +159,43 @@ both default values `and environment variables`.
 
    Default: ``"http://wso2.org/claims/url"``
 
+Second section with SAML
+++++++++++++++++++++++++
+
+.. todo::
+
+      Fix this section. Merge or find better name.
+
+.. py:data:: SAML_IDP_METADATA_URL
+
+   Default: ``"https://172.16.20.100/simplesaml/saml2/idp/metadata.php"``
+
+.. py:data:: SAML_IDP_INSECURE
+
+   Default: ``False``
+
+.. py:data:: SAML_REQUESTS_SIGNED
+
+   Default: ``False``
+
+.. py:data:: SAML_KEY_FILE
+
+   Default: ``None``
+
+.. py:data:: SAML_CERT_FILE
+
+   Default: ``None``
+
+.. py:data:: SAML_AUTH_ENABLE
+
+   Default: ``False``
+
+Authorization
+-------------
+
+.. todo::
+
+      Fix this section. Maby merge with SAML.
 
 # Whether authorization is enabled.
 
@@ -165,7 +224,12 @@ both default values `and environment variables`.
 
 
 
-# Log AMQP settings
+Log AMQP
+--------
+
+.. todo::
+
+      Fix this section.
 
 .. py:data:: LOG_AMQP_SERVER
 
@@ -190,29 +254,13 @@ both default values `and environment variables`.
 
    Default: ``"/var/log/mox/audit.log"``
 
-.. py:data:: SAML_IDP_METADATA_URL
 
-   Default: ``"https://172.16.20.100/simplesaml/saml2/idp/metadata.php"``
+Session
+-------
 
-.. py:data:: SAML_IDP_INSECURE
+.. todo::
 
-   Default: ``False``
-
-.. py:data:: SAML_REQUESTS_SIGNED
-
-   Default: ``False``
-
-.. py:data:: SAML_KEY_FILE
-
-   Default: ``None``
-
-.. py:data:: SAML_CERT_FILE
-
-   Default: ``None``
-
-.. py:data:: SAML_AUTH_ENABLE
-
-   Default: ``False``
+      Fix this section.
 
 .. py:data:: SQLALCHEMY_DATABASE_URI
 

--- a/doc/user/settings.rst
+++ b/doc/user/settings.rst
@@ -3,9 +3,9 @@ Settings
 ========
 
 Most configurable parameters of ``oio_rest`` can be injected with environment
-variables. Alternatively you may set the parameters in a file.
+variables. Alternatively, you may set the parameters in a file.
 
-Environment variables overwrites default values. The settings file overwrite
+Environment variables overwrite default values. The settings file overwrites
 both default values `and environment variables`.
 
 .. py:data:: CONFIG_FILE

--- a/doc/user/settings.rst
+++ b/doc/user/settings.rst
@@ -233,36 +233,37 @@ Authorization
 
 
 
-Log AMQP
---------
+Audit log
+---------
 
-.. todo::
-
-      Fix this section.
+An audit log is published as AMQP messages and written to a file.
 
 .. py:data:: LOG_AMQP_SERVER
 
    Default: ``"localhost"``
 
+   The AMQP server used to publish the audit log.
+
+   Not to be confused by the AMQP service used by
+   :file:`/python_agents/notification_service/notify_to_amqp_service.py`.
+
 .. py:data:: MOX_LOG_EXCHANGE
 
    Default: ``"mox.log"``
+
+   The AMQP exchange used for the audit log.
 
 .. py:data:: MOX_LOG_QUEUE
 
    Default: ``"mox.log_queue"``
 
-.. py:data:: LOG_IGNORED_SERVICES
-
-   Default: ``['Log', ]``
-
-   .. warning::
-      No ENV variable
-
+   The AMQP queue used for the audit log.
 
 .. py:data:: AUDIT_LOG_FILE
 
    Default: ``"/var/log/mox/audit.log"``
+
+   The path to a log file where the audit log is written.
 
 
 Session

--- a/doc/user/settings.rst
+++ b/doc/user/settings.rst
@@ -30,7 +30,7 @@ both default values `and environment variables`.
 
 
 Database
---------
+========
 
 PostgreSQL
 
@@ -90,7 +90,7 @@ PostgreSQL
 
 
 File upload
------------
+===========
 
 .. py:data:: FILE_UPLOAD_FOLDER
 
@@ -102,139 +102,8 @@ File upload
 
 
 
-SAML
-----
-
-.. todo::
-
-      Fix this section.
-
-# The Endpoint specified in the AppliesTo element of the STS request
-# This will be used to verify the Audience of the SAML Assertion
-
-.. py:data:: SAML_MOX_ENTITY_ID
-
-   Default: ``"https://saml.local'"``
-
-
-
-# The Entity ID of the IdP. Used to verify the token Issuer --
-# specified in AD FS as the Federation Service identifier.
-# Example: 'http://fs.contoso.com/adfs/services/trust'
-
-.. py:data:: SAML_IDP_ENTITY_ID
-
-   Default: ``"localhost"``
-
-
-
-# The URL on which to access the SAML IdP.
-# Example: 'https://fs.contoso.com/adfs/services/trust/13/UsernameMixed'
-
-.. py:data:: SAML_IDP_URL
-
-   Default: ``"https://localhost:9443/services/wso2carbon-sts.wso2carbon-stsHttpsEndpoint"``
-
-# We currently support authentication against 'wso2' and 'adfs'
-
-.. py:data:: SAML_IDP_TYPE
-
-   Default: ``"wso2"``
-
-
-
-# The public certificate file of the IdP, in PEM-format.
-
-.. py:data:: SAML_IDP_CERTIFICATE
-
-   Default: ``"test_auth_data/idp-certificate.pem"``
-
-
-
-# Whether to enable SAML authentication
-
-.. py:data:: USE_SAML_AUTHENTICATION
-
-   Default: ``False``
-
-
-
-# SAML user ID attribute -- default is for WSO2
-# Example:
-#   http://schemas.xmlsoap.org
-#       /ws/2005/05/identity/claims/privatepersonalidentifier
-
-.. py:data:: SAML_USER_ID_ATTIBUTE
-
-   Default: ``"http://wso2.org/claims/url"``
-
-Second section with SAML
-++++++++++++++++++++++++
-
-.. todo::
-
-      Fix this section. Merge or find better name.
-
-.. py:data:: SAML_IDP_METADATA_URL
-
-   Default: ``"https://172.16.20.100/simplesaml/saml2/idp/metadata.php"``
-
-.. py:data:: SAML_IDP_INSECURE
-
-   Default: ``False``
-
-.. py:data:: SAML_REQUESTS_SIGNED
-
-   Default: ``False``
-
-.. py:data:: SAML_KEY_FILE
-
-   Default: ``None``
-
-.. py:data:: SAML_CERT_FILE
-
-   Default: ``None``
-
-.. py:data:: SAML_AUTH_ENABLE
-
-   Default: ``False``
-
-Authorization
--------------
-
-.. todo::
-
-      Fix this section. Maby merge with SAML.
-
-# Whether authorization is enabled.
-
-# If not, the restrictions module is not called.
-
-.. py:data:: DO_ENABLE_RESTRICTIONS
-
-   Default: ``False``
-
-
-# The module which implements the authorization restrictions.
-# Must be present in sys.path.
-
-.. py:data:: AUTH_RESTRICTION_MODULE
-
-   Default: ``"oio_rest.auth.wso_restrictions"``
-
-
-
-# The name of the function which retrieves the restrictions.
-# Must be present in AUTH_RESTRICTION_MODULE and have the correct signature.
-
-.. py:data:: AUTH_RESTRICTION_FUNCTION
-
-   Default: ``"get_auth_restrictions"``
-
-
-
 Audit log
----------
+=========
 
 An audit log is published as AMQP messages and written to a file.
 
@@ -266,21 +135,161 @@ An audit log is published as AMQP messages and written to a file.
    The path to a log file where the audit log is written.
 
 
-Session
--------
+.. _auth-settings:
 
+Authentication
+==============
 .. todo::
 
-      Fix this section.
+      Fix this whole section as part of #25911.
+
+MOX have two independent ways to use SAML. A older one from the file
+:file:`mox/oio_rest/oio_rest/auth/saml2.py` and a newer one from the package
+`flask_saml_sso <https://github.com/magenta-aps/flask_saml_sso>`_. Only use one
+of them at a time. They are both disabled by default. For a overview of how
+:file:`mox/oio_rest/oio_rest/auth/saml2.py` works, see :ref:`auth`.
+
+SAML from :file:`mox/oio_rest/oio_rest/auth/saml2.py`
+------------------------------------------------------
+
+.. py:data:: USE_SAML_AUTHENTICATION
+
+   Default: ``False``
+
+   Whether to enable SAML authentication from :file:`mox/oio_rest/oio_rest/auth/saml2.py`.
+
+.. py:data:: SAML_MOX_ENTITY_ID
+
+   Default: ``"https://saml.local'"``
+
+   The Endpoint specified in the AppliesTo element of the STS request. This will
+   be used to verify the Audience of the SAML Assertion.
+
+
+.. py:data:: SAML_IDP_ENTITY_ID
+
+   Default: ``"localhost"``
+
+   The Entity ID of the IdP. Used to verify the token Issuer specified in AD FS
+   as the Federation Service identifier.
+
+   Example: ``"http://fs.contoso.com/adfs/services/trust"``
+
+
+.. py:data:: SAML_IDP_URL
+
+   Default: ``"https://localhost:9443/services/wso2carbon-sts.wso2carbon-stsHttpsEndpoint"``
+
+   The URL on which to access the SAML IdP.
+
+   Example: ``"https://fs.contoso.com/adfs/services/trust/13/UsernameMixed"``
+
+
+.. py:data:: SAML_IDP_TYPE
+
+   Default: ``"wso2"``
+
+   We currently support authentication against ``wso2`` and ``adfs``.
+
+
+.. py:data:: SAML_IDP_CERTIFICATE
+
+   Default: ``"test_auth_data/idp-certificate.pem"``
+
+   The public certificate file of the IdP, in PEM-format.
+
+
+.. py:data:: SAML_USER_ID_ATTIBUTE
+
+   Default: ``"http://wso2.org/claims/url"``
+
+   SAML user ID attribute. Default is for WSO2
+
+   Example:
+   ``"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/privatepersonalidentifier"``
+
+
+
+SAML from ``flask_saml_sso``
+----------------------------
+
+Refer to the readme for `flask_saml_sso
+<https://github.com/magenta-aps/flask_saml_sso>`_ for these settings.
+
+
+.. py:data:: SAML_AUTH_ENABLE
+
+   Default: ``False``
+
+   Whether to enable SAML authentication from ``flask_saml_sso``.
+
+.. py:data:: SAML_IDP_METADATA_URL
+
+   Default: ``"https://172.16.20.100/simplesaml/saml2/idp/metadata.php"``
+
+
+.. py:data:: SAML_IDP_INSECURE
+
+   Default: ``False``
+
+
+.. py:data:: SAML_REQUESTS_SIGNED
+
+   Default: ``False``
+
+
+.. py:data:: SAML_KEY_FILE
+
+   Default: ``None``
+
+
+.. py:data:: SAML_CERT_FILE
+
+   Default: ``None``
+
 
 .. py:data:: SQLALCHEMY_DATABASE_URI
 
    Default: ``"postgresql://sessions:sessions@127.0.0.1/sessions"``
 
+
 .. py:data:: SESSION_PERMANENT
 
    Default: ``True``
 
+
 .. py:data:: PERMANENT_SESSION_LIFETIME
 
    Default: ``3600``
+
+
+Restrictions
+============
+
+.. todo::
+
+      Fix this section.
+
+
+.. py:data:: DO_ENABLE_RESTRICTIONS
+
+   Default: ``False``
+
+   Whether authorization is enabled. If not, the :data:`AUTH_RESTRICTION_MODULE`
+   is not called.
+
+
+.. py:data:: AUTH_RESTRICTION_MODULE
+
+   Default: ``"oio_rest.auth.wso_restrictions"``
+
+   The module which implements the authorization restrictions.
+   Must be present in ``sys.path``.
+
+
+.. py:data:: AUTH_RESTRICTION_FUNCTION
+
+   Default: ``"get_auth_restrictions"``
+
+   The name of the function which retrieves the restrictions. Must be present in
+   :data:`AUTH_RESTRICTION_MODULE` and have the correct signature.

--- a/doc/user/settings.rst
+++ b/doc/user/settings.rst
@@ -1,0 +1,154 @@
+========
+Settings
+========
+
+
+.. py:data:: CONFIG_FILE = os.getenv('OIO_REST_CONFIG_FILE', None)
+
+.. py:data:: BASE_URL = os.getenv('BASE_URL', '')
+
+
+
+# Database (PostgreSQL) settings
+
+.. py:data:: DB_HOST = os.getenv('DB_HOST', "localhost")
+
+.. py:data:: DB_PORT = int(os.getenv('DB_PORT', '0')) or None
+
+.. py:data:: DB_USER = os.getenv('DB_USER', "mox")
+
+.. py:data:: DB_PASSWORD = os.getenv('DB_PASSWORD', "mox")
+
+
+
+# name of database, should be changed to use `DB_` convention.
+
+.. py:data:: DATABASE = os.getenv('DB_NAME' ,"mox")
+
+
+
+# Per-process limits on the amount of database connections. Setting the minimum
+# to a non-zero value ensures that the webapp opens this amount at load,
+# failing if the database isn't available.
+
+.. py:data:: DB_MIN_CONNECTIONS = int(os.getenv('DB_MIN_CONNECTIONS', '0'))
+
+.. py:data:: DB_MAX_CONNECTIONS = int(os.getenv('DB_MAX_CONNECTIONS', '10'))
+
+.. py:data:: DB_STRUCTURE = os.getenv('DB_STRUCTURE', 'oio_rest.db.db_structure')
+
+
+
+# This is where file uploads are stored. It must be readable and writable by
+# the mox user, running the REST API server. This is used in the Dokument
+# hierarchy.
+
+.. py:data:: FILE_UPLOAD_FOLDER = os.getenv('FILE_UPLOAD_FOLDER', '/var/mox')
+
+
+
+# The Endpoint specified in the AppliesTo element of the STS request
+# This will be used to verify the Audience of the SAML Assertion
+
+.. py:data:: SAML_MOX_ENTITY_ID = os.getenv('SAML_MOX_ENTITY_ID', 'https://saml.local')
+
+
+
+# The Entity ID of the IdP. Used to verify the token Issuer --
+# specified in AD FS as the Federation Service identifier.
+# Example: 'http://fs.contoso.com/adfs/services/trust'
+
+.. py:data:: SAML_IDP_ENTITY_ID = os.getenv('SAML_IDP_ENTITY_ID', 'localhost')
+
+
+
+# The URL on which to access the SAML IdP.
+# Example: 'https://fs.contoso.com/adfs/services/trust/13/UsernameMixed'
+
+.. py:data:: SAML_IDP_URL = os.getenv('SAML_IDP_URL', 'https://localhost:9443/services/wso2carbon-sts.wso2carbon-stsHttpsEndpoint')
+
+
+# We currently support authentication against 'wso2' and 'adfs'
+
+.. py:data:: SAML_IDP_TYPE = os.getenv('SAML_IDP_TYPE', 'wso2')
+
+
+
+# The public certificate file of the IdP, in PEM-format.
+
+.. py:data:: SAML_IDP_CERTIFICATE = os.getenv('SAML_IDP_CERTIFICATE', 'test_auth_data/idp-certificate.pem')
+
+
+
+# Whether to enable SAML authentication
+.. py:data:: USE_SAML_AUTHENTICATION = os.getenv('USE_SAML_AUTHENTICATION', False)
+
+
+
+# SAML user ID attribute -- default is for WSO2
+# Example:
+#   http://schemas.xmlsoap.org
+#       /ws/2005/05/identity/claims/privatepersonalidentifier
+
+.. py:data:: SAML_USER_ID_ATTIBUTE = os.getenv('SAML_USER_ID_ATTIBUTE', 'http://wso2.org/claims/url')
+
+
+
+# Whether authorization is enabled.
+
+# If not, the restrictions module is not called.
+
+.. py:data:: DO_ENABLE_RESTRICTIONS = os.getenv('DO_ENABLE_RESTRICTIONS', False)
+
+
+# The module which implements the authorization restrictions.
+# Must be present in sys.path.
+
+.. py:data:: AUTH_RESTRICTION_MODULE = os.getenv('AUTH_RESTRICTION_MODULE', 'oio_rest.auth.wso_restrictions',)
+
+
+
+# The name of the function which retrieves the restrictions.
+# Must be present in AUTH_RESTRICTION_MODULE and have the correct signature.
+
+.. py:data:: AUTH_RESTRICTION_FUNCTION = os.getenv('AUTH_RESTRICTION_FUNCTION','get_auth_restrictions',)
+
+
+
+# Log AMQP settings
+
+.. py:data:: LOG_AMQP_SERVER = os.getenv('LOG_AMQP_SERVER', 'localhost')
+
+.. py:data:: MOX_LOG_EXCHANGE = os.getenv('MOX_LOG_EXCHANGE', 'mox.log')
+
+.. py:data:: MOX_LOG_QUEUE = os.getenv('MOX_LOG_QUEUE', 'mox.log_queue')
+
+
+
+.. py:data:: LOG_IGNORED_SERVICES = ['Log', ]
+
+
+
+.. py:data:: AUDIT_LOG_FILE = os.getenv('AUDIT_LOG_FILE', '/var/log/mox/audit.log')
+
+
+
+.. py:data:: SAML_IDP_METADATA_URL = os.getenv('SAML_IDP_METADATA_URL', 'https://172.16.20.100/simplesaml/saml2/idp/metadata.php')
+
+.. py:data:: SAML_IDP_INSECURE = os.getenv('SAML_IDP_INSECURE', False)
+
+.. py:data:: SAML_REQUESTS_SIGNED = os.getenv('SAML_REQUESTS_SIGNED', False)
+
+.. py:data:: SAML_KEY_FILE = os.getenv('SAML_KEY_FILE', None)
+
+.. py:data:: SAML_CERT_FILE = os.getenv('SAML_CERT_FILE', None)
+
+.. py:data:: SAML_AUTH_ENABLE = os.getenv('SAML_AUTH_ENABLE', False)
+
+
+
+.. py:data:: SQLALCHEMY_DATABASE_URI = os.getenv('SQLALCHEMY_DATABASE_URI', "postgresql://sessions:sessions@127.0.0.1/sessions",)
+
+.. py:data:: SESSION_PERMANENT = os.getenv('SESSION_PERMANENT', True)
+
+.. py:data:: PERMANENT_SESSION_LIFETIME = os.getenv('PERMANENT_SESSION_LIFETIME', 3600)

--- a/doc/user/settings.rst
+++ b/doc/user/settings.rst
@@ -92,17 +92,15 @@ PostgreSQL
 File upload
 -----------
 
-.. todo::
-
-      Fix this section.
-
-# This is where file uploads are stored. It must be readable and writable by
-# the mox user, running the REST API server. This is used in the Dokument
-# hierarchy.
-
 .. py:data:: FILE_UPLOAD_FOLDER
 
    Default: ``"/var/mox"``
+
+   This path is where file uploads are stored. It must be readable and writable by
+   the system user running the REST API server. This is used in the Dokument
+   hierarchy.
+
+
 
 SAML
 ----

--- a/doc/user/settings.rst
+++ b/doc/user/settings.rst
@@ -10,6 +10,8 @@ both default values `and environment variables`.
 
 .. py:data:: CONFIG_FILE
 
+   Default: ``None``
+
    Setting the environment variable :data:`CONFIG_FILE` to a a path to a JSON
    file containing a dict of ``"<setting>": <value>`` pairs will load the
    settings specified in the file.
@@ -17,16 +19,14 @@ both default values `and environment variables`.
    The settings from the file have precedens over any environment variables and
    will overwrite their values.
 
-   Default: ``None``
-
 
 .. py:data:: BASE_URL
+
+   Default: ``""`` (Empty string)
 
    .. todo::
 
       Fill out this section.
-
-   Default: ``""``
 
 
 Database
@@ -245,10 +245,11 @@ Log AMQP
 
 .. py:data:: LOG_IGNORED_SERVICES
 
+   Default: ``['Log', ]``
+
    .. warning::
       No ENV variable
 
-   Default: ``['Log', ]``
 
 .. py:data:: AUDIT_LOG_FILE
 

--- a/doc/user/settings.rst
+++ b/doc/user/settings.rst
@@ -83,10 +83,8 @@ PostgreSQL
 
    Default: ``"oio_rest.db.db_structure"``
 
-   .. todo::
-
-      Document this setting. Introduced in 539789191cba59ffc721f9db511ef1bcb949c848
-
+   The structure of the whole database. Overwrite this if you want to extend the
+   database with additional fields on the objects.
 
 File upload
 ===========

--- a/doc/user/settings.rst
+++ b/doc/user/settings.rst
@@ -24,9 +24,8 @@ both default values `and environment variables`.
 
    Default: ``""`` (Empty string)
 
-   .. todo::
-
-      Fill out this section.
+   Prefix for all relative URLs. A value of ``"/MyOIO"`` will give API endpoints
+   such as ``http://example.com/MyOIO/organisation/organisationenhed``.
 
 
 Database

--- a/doc/user/settings.rst
+++ b/doc/user/settings.rst
@@ -12,11 +12,11 @@ both default values `and environment variables`.
 
    Default: ``None``
 
-   Setting the environment variable :data:`CONFIG_FILE` to a a path to a JSON
-   file containing a dict of ``"<setting>": <value>`` pairs will load the
+   Setting the environment variable :data:`CONFIG_FILE` to a path to a JSON
+   file containing a dictionary of ``"<setting>": <value>`` pairs will load the
    settings specified in the file.
 
-   The settings from the file have precedens over any environment variables and
+   The settings from the file have precedence over any environment variables and
    will overwrite their values.
 
 
@@ -38,7 +38,7 @@ PostgreSQL
 
    Default: ``"localhost"``
 
-   Which host to use when connecting to the database.
+   The host to use when connecting to the database.
 
 .. py:data:: DB_PORT
 
@@ -70,8 +70,8 @@ PostgreSQL
    Default: ``0``
 
    Per-process lower limit on the amount of database connections. Setting it to
-   a non-zero value ensures that the webapp opens this amount at load, failing
-   if the database isn't available.
+   a non-zero value ensures that the web application opens this amount at load,
+   failing if the database isn't available.
 
 .. py:data:: DB_MAX_CONNECTIONS
 
@@ -93,8 +93,8 @@ File upload
 
    Default: ``"/var/mox"``
 
-   This path is where file uploads are stored. It must be readable and writable by
-   the system user running the REST API server. This is used in the Dokument
+   This path is where file uploads are stored. It must be readable and writeable
+   by the system user running the REST API server. This is used in the Dokument
    hierarchy.
 
 
@@ -140,10 +140,10 @@ Authentication
 
       Fix this whole section as part of #25911.
 
-MOX have two independent ways to use SAML. A older one from the file
+MOX have two independent ways to use SAML. An older one from the file
 :file:`mox/oio_rest/oio_rest/auth/saml2.py` and a newer one from the package
 `flask_saml_sso <https://github.com/magenta-aps/flask_saml_sso>`_. Only use one
-of them at a time. They are both disabled by default. For a overview of how
+of them at a time. They are both disabled by default. For an overview of how
 :file:`mox/oio_rest/oio_rest/auth/saml2.py` works, see :ref:`auth`.
 
 SAML from :file:`mox/oio_rest/oio_rest/auth/saml2.py`
@@ -159,8 +159,8 @@ SAML from :file:`mox/oio_rest/oio_rest/auth/saml2.py`
 
    Default: ``"https://saml.local'"``
 
-   The Endpoint specified in the AppliesTo element of the STS request. This will
-   be used to verify the Audience of the SAML Assertion.
+   The Endpoint specified in the ``AppliesTo`` element of the STS request. This
+   will be used to verify the Audience of the SAML Assertion.
 
 
 .. py:data:: SAML_IDP_ENTITY_ID
@@ -218,7 +218,7 @@ Refer to the readme for `flask_saml_sso
 
    Default: ``False``
 
-   Whether to enable SAML authentication from ``flask_saml_sso``.
+   Enables SAML authentication from ``flask_saml_sso``.
 
 .. py:data:: SAML_IDP_METADATA_URL
 

--- a/doc/user/settings.rst
+++ b/doc/user/settings.rst
@@ -34,49 +34,60 @@ Database
 
 PostgreSQL
 
-.. todo::
-
-      Fill out this section.
 
 .. py:data:: DB_HOST
 
    Default: ``"localhost"``
 
+   Which host to use when connecting to the database.
+
 .. py:data:: DB_PORT
 
-   Default: ``0``
+   Default: ``None``
+
+   The port to use when connecting to the database specified in :data:`DB_HOST`.
 
 .. py:data:: DB_USER
 
    Default: ``"mox"``
 
+   The username to use when connecting to the database.
+
 .. py:data:: DB_PASSWORD
 
    Default: ``"mox"``
 
-
-# name of database, should be changed to use `DB_` convention.
+   The password to use when connecting to the database.
 
 .. py:data:: DATABASE
 
    Default: ``"mox"``
 
+   The name of the database to use.
 
-# Per-process limits on the amount of database connections. Setting the minimum
-# to a non-zero value ensures that the webapp opens this amount at load,
-# failing if the database isn't available.
 
 .. py:data:: DB_MIN_CONNECTIONS
 
    Default: ``0``
 
+   Per-process lower limit on the amount of database connections. Setting it to
+   a non-zero value ensures that the webapp opens this amount at load, failing
+   if the database isn't available.
+
 .. py:data:: DB_MAX_CONNECTIONS
 
    Default: ``10``
 
+   Per-process upper limit on the amount of database connections.
+
 .. py:data:: DB_STRUCTURE
 
    Default: ``"oio_rest.db.db_structure"``
+
+   .. todo::
+
+      Document this setting. Introduced in 539789191cba59ffc721f9db511ef1bcb949c848
+
 
 File upload
 -----------

--- a/doc/user/settings.rst
+++ b/doc/user/settings.rst
@@ -3,54 +3,74 @@ Settings
 ========
 
 
-.. py:data:: CONFIG_FILE = os.getenv('OIO_REST_CONFIG_FILE', None)
+.. py:data:: CONFIG_FILE
 
-.. py:data:: BASE_URL = os.getenv('BASE_URL', '')
+   Default: ``None``
 
+.. py:data:: BASE_URL
+
+   Default: ``""``
 
 
 # Database (PostgreSQL) settings
 
-.. py:data:: DB_HOST = os.getenv('DB_HOST', "localhost")
+.. py:data:: DB_HOST
 
-.. py:data:: DB_PORT = int(os.getenv('DB_PORT', '0')) or None
+   Default: ``"localhost"``
 
-.. py:data:: DB_USER = os.getenv('DB_USER', "mox")
+.. py:data:: DB_PORT
 
-.. py:data:: DB_PASSWORD = os.getenv('DB_PASSWORD', "mox")
+   Default: ``0``
 
+.. py:data:: DB_USER
+
+   Default: ``"mox"``
+
+.. py:data:: DB_PASSWORD
+
+   Default: ``"mox"``
 
 
 # name of database, should be changed to use `DB_` convention.
 
-.. py:data:: DATABASE = os.getenv('DB_NAME' ,"mox")
+.. py:data:: DATABASE
 
+   Default: ``"mox"``
 
 
 # Per-process limits on the amount of database connections. Setting the minimum
 # to a non-zero value ensures that the webapp opens this amount at load,
 # failing if the database isn't available.
 
-.. py:data:: DB_MIN_CONNECTIONS = int(os.getenv('DB_MIN_CONNECTIONS', '0'))
+.. py:data:: DB_MIN_CONNECTIONS
 
-.. py:data:: DB_MAX_CONNECTIONS = int(os.getenv('DB_MAX_CONNECTIONS', '10'))
+   Default: ``0``
 
-.. py:data:: DB_STRUCTURE = os.getenv('DB_STRUCTURE', 'oio_rest.db.db_structure')
+.. py:data:: DB_MAX_CONNECTIONS
 
+   Default: ``10``
+
+.. py:data:: DB_STRUCTURE
+
+   Default: ``"oio_rest.db.db_structure"``
 
 
 # This is where file uploads are stored. It must be readable and writable by
 # the mox user, running the REST API server. This is used in the Dokument
 # hierarchy.
 
-.. py:data:: FILE_UPLOAD_FOLDER = os.getenv('FILE_UPLOAD_FOLDER', '/var/mox')
+.. py:data:: FILE_UPLOAD_FOLDER
+
+   Default: ``"/var/mox"``
 
 
 
 # The Endpoint specified in the AppliesTo element of the STS request
 # This will be used to verify the Audience of the SAML Assertion
 
-.. py:data:: SAML_MOX_ENTITY_ID = os.getenv('SAML_MOX_ENTITY_ID', 'https://saml.local')
+.. py:data:: SAML_MOX_ENTITY_ID
+
+   Default: ``"https://saml.local'"``
 
 
 
@@ -58,30 +78,40 @@ Settings
 # specified in AD FS as the Federation Service identifier.
 # Example: 'http://fs.contoso.com/adfs/services/trust'
 
-.. py:data:: SAML_IDP_ENTITY_ID = os.getenv('SAML_IDP_ENTITY_ID', 'localhost')
+.. py:data:: SAML_IDP_ENTITY_ID
+
+   Default: ``"localhost"``
 
 
 
 # The URL on which to access the SAML IdP.
 # Example: 'https://fs.contoso.com/adfs/services/trust/13/UsernameMixed'
 
-.. py:data:: SAML_IDP_URL = os.getenv('SAML_IDP_URL', 'https://localhost:9443/services/wso2carbon-sts.wso2carbon-stsHttpsEndpoint')
+.. py:data:: SAML_IDP_URL
 
+   Default: ``"https://localhost:9443/services/wso2carbon-sts.wso2carbon-stsHttpsEndpoint"``
 
 # We currently support authentication against 'wso2' and 'adfs'
 
-.. py:data:: SAML_IDP_TYPE = os.getenv('SAML_IDP_TYPE', 'wso2')
+.. py:data:: SAML_IDP_TYPE
+
+   Default: ``"wso2"``
 
 
 
 # The public certificate file of the IdP, in PEM-format.
 
-.. py:data:: SAML_IDP_CERTIFICATE = os.getenv('SAML_IDP_CERTIFICATE', 'test_auth_data/idp-certificate.pem')
+.. py:data:: SAML_IDP_CERTIFICATE
+
+   Default: ``"test_auth_data/idp-certificate.pem"``
 
 
 
 # Whether to enable SAML authentication
-.. py:data:: USE_SAML_AUTHENTICATION = os.getenv('USE_SAML_AUTHENTICATION', False)
+
+.. py:data:: USE_SAML_AUTHENTICATION
+
+   Default: ``False``
 
 
 
@@ -90,65 +120,95 @@ Settings
 #   http://schemas.xmlsoap.org
 #       /ws/2005/05/identity/claims/privatepersonalidentifier
 
-.. py:data:: SAML_USER_ID_ATTIBUTE = os.getenv('SAML_USER_ID_ATTIBUTE', 'http://wso2.org/claims/url')
+.. py:data:: SAML_USER_ID_ATTIBUTE
 
+   Default: ``"http://wso2.org/claims/url"``
 
 
 # Whether authorization is enabled.
 
 # If not, the restrictions module is not called.
 
-.. py:data:: DO_ENABLE_RESTRICTIONS = os.getenv('DO_ENABLE_RESTRICTIONS', False)
+.. py:data:: DO_ENABLE_RESTRICTIONS
+
+   Default: ``False``
 
 
 # The module which implements the authorization restrictions.
 # Must be present in sys.path.
 
-.. py:data:: AUTH_RESTRICTION_MODULE = os.getenv('AUTH_RESTRICTION_MODULE', 'oio_rest.auth.wso_restrictions',)
+.. py:data:: AUTH_RESTRICTION_MODULE
+
+   Default: ``"oio_rest.auth.wso_restrictions"``
 
 
 
 # The name of the function which retrieves the restrictions.
 # Must be present in AUTH_RESTRICTION_MODULE and have the correct signature.
 
-.. py:data:: AUTH_RESTRICTION_FUNCTION = os.getenv('AUTH_RESTRICTION_FUNCTION','get_auth_restrictions',)
+.. py:data:: AUTH_RESTRICTION_FUNCTION
+
+   Default: ``"get_auth_restrictions"``
 
 
 
 # Log AMQP settings
 
-.. py:data:: LOG_AMQP_SERVER = os.getenv('LOG_AMQP_SERVER', 'localhost')
+.. py:data:: LOG_AMQP_SERVER
 
-.. py:data:: MOX_LOG_EXCHANGE = os.getenv('MOX_LOG_EXCHANGE', 'mox.log')
+   Default: ``"localhost"``
 
-.. py:data:: MOX_LOG_QUEUE = os.getenv('MOX_LOG_QUEUE', 'mox.log_queue')
+.. py:data:: MOX_LOG_EXCHANGE
 
+   Default: ``"mox.log"``
 
+.. py:data:: MOX_LOG_QUEUE
 
-.. py:data:: LOG_IGNORED_SERVICES = ['Log', ]
+   Default: ``"mox.log_queue"``
 
+.. py:data:: LOG_IGNORED_SERVICES
 
+   .. warning::
+      No ENV variable
 
-.. py:data:: AUDIT_LOG_FILE = os.getenv('AUDIT_LOG_FILE', '/var/log/mox/audit.log')
+   Default: ``['Log', ]``
 
+.. py:data:: AUDIT_LOG_FILE
 
+   Default: ``"/var/log/mox/audit.log"``
 
-.. py:data:: SAML_IDP_METADATA_URL = os.getenv('SAML_IDP_METADATA_URL', 'https://172.16.20.100/simplesaml/saml2/idp/metadata.php')
+.. py:data:: SAML_IDP_METADATA_URL
 
-.. py:data:: SAML_IDP_INSECURE = os.getenv('SAML_IDP_INSECURE', False)
+   Default: ``"https://172.16.20.100/simplesaml/saml2/idp/metadata.php"``
 
-.. py:data:: SAML_REQUESTS_SIGNED = os.getenv('SAML_REQUESTS_SIGNED', False)
+.. py:data:: SAML_IDP_INSECURE
 
-.. py:data:: SAML_KEY_FILE = os.getenv('SAML_KEY_FILE', None)
+   Default: ``False``
 
-.. py:data:: SAML_CERT_FILE = os.getenv('SAML_CERT_FILE', None)
+.. py:data:: SAML_REQUESTS_SIGNED
 
-.. py:data:: SAML_AUTH_ENABLE = os.getenv('SAML_AUTH_ENABLE', False)
+   Default: ``False``
 
+.. py:data:: SAML_KEY_FILE
 
+   Default: ``None``
 
-.. py:data:: SQLALCHEMY_DATABASE_URI = os.getenv('SQLALCHEMY_DATABASE_URI', "postgresql://sessions:sessions@127.0.0.1/sessions",)
+.. py:data:: SAML_CERT_FILE
 
-.. py:data:: SESSION_PERMANENT = os.getenv('SESSION_PERMANENT', True)
+   Default: ``None``
 
-.. py:data:: PERMANENT_SESSION_LIFETIME = os.getenv('PERMANENT_SESSION_LIFETIME', 3600)
+.. py:data:: SAML_AUTH_ENABLE
+
+   Default: ``False``
+
+.. py:data:: SQLALCHEMY_DATABASE_URI
+
+   Default: ``"postgresql://sessions:sessions@127.0.0.1/sessions"``
+
+.. py:data:: SESSION_PERMANENT
+
+   Default: ``True``
+
+.. py:data:: PERMANENT_SESSION_LIFETIME
+
+   Default: ``3600``


### PR DESCRIPTION
Jeg har lavet dokumentation af settings til `oio_rest`. Det meste er taget fra `settings.py`.

Jeg har ikke dokumenteret SAML så godt. Jeg har fyldt det under ticket 25911 der er en bredere ticket der dækker alt auth dokumentation.