### PR TITLE
#27147 simplify validation

### DIFF
--- a/oio_rest/oio_rest/oio_rest.py
+++ b/oio_rest/oio_rest/oio_rest.py
@@ -248,7 +248,7 @@ class OIORestObject(object):
 
         # Validate JSON input
         try:
-            validate.validate(input)
+            validate.validate(input, cls.__name__.lower())
         except jsonschema.exceptions.ValidationError as e:
             return jsonify({'message': e.message}), 400
 
@@ -421,7 +421,7 @@ class OIORestObject(object):
 
         # Validate JSON input
         try:
-            validate.validate(input)
+            validate.validate(input, cls.__name__.lower())
         except jsonschema.exceptions.ValidationError as e:
             return jsonify({'message': e.message}), 400
 

--- a/oio_rest/oio_rest/validate.py
+++ b/oio_rest/oio_rest/validate.py
@@ -360,39 +360,6 @@ def _generate_varianter():
     ))
 
 
-def get_lora_object_type(req):
-    """
-    Get the LoRa object type from the request.
-    :param req: The JSON body from the LoRa request.
-    :raise jsonschema.exceptions.ValidationError: If the LoRa object type
-    cannot be determined.
-    :return: The LoRa object type, i.e. 'organisation', 'bruger',...
-    """
-
-    jsonschema.validate(
-        req,
-        {
-            'type': 'object',
-            'properties': {
-                'attributter': {
-                    'type': 'object',
-                },
-
-            },
-            'required': ['attributter']
-        }
-    )
-
-    # TODO: this can probably be made smarter using the "oneOf" JSON schema
-    # keyword in the schema above, but there were problems getting this to work
-
-    if not list(req['attributter'].keys())[0] in [key + 'egenskaber' for key in
-                                                  settings.REAL_DB_STRUCTURE.keys()]:
-        raise jsonschema.exceptions.ValidationError('ups2')
-
-    return list(req['attributter'].keys())[0].split('egenskaber')[0]
-
-
 def generate_json_schema(obj):
     """
     Generate the JSON schema corresponding to LoRa object type.
@@ -467,7 +434,7 @@ def get_schema(obj_type):
     return schema
 
 
-def validate(input_json):
+def validate(input_json, obj_type):
     """
     Validate request JSON according to JSON schema.
     :param input_json: The request JSON
@@ -475,5 +442,4 @@ def validate(input_json):
     valid according to the JSON schema.
     """
 
-    obj_type = get_lora_object_type(input_json)
     jsonschema.validate(input_json, get_schema(obj_type))

--- a/oio_rest/tests/fixtures/interessefaellesskab_opret.json
+++ b/oio_rest/tests/fixtures/interessefaellesskab_opret.json
@@ -1,0 +1,38 @@
+{
+    "attributter": {
+        "interessefaellesskabegenskaber": [
+            {
+                "brugervendtnoegle": "bvn",
+                "interessefaellesskabsnavn": "Hesteholdere",
+                "interessefaellesskabstype": "Forening",
+                "virkning": {
+                    "from": "2017-01-01 00:00:00+01:00",
+                    "to": "infinity"
+                }
+            }
+        ]
+    },
+    "note": "Automatisk indl\u00e6sning",
+    "relationer": {
+        "interessefaellesskabstype": [
+            {
+                "urn": "urn:1337",
+                "virkning": {
+                    "from": "2017-01-01 00:00:00+01:00",
+                    "to": "infinity"
+                }
+            }
+        ]
+    },
+    "tilstande": {
+        "interessefaellesskabgyldighed": [
+            {
+                "gyldighed": "Aktiv",
+                "virkning": {
+                    "from": "2017-01-01 00:00:00+01:00",
+                    "to": "infinity"
+                }
+            }
+        ]
+    }
+}

--- a/oio_rest/tests/fixtures/organisation_opret.json
+++ b/oio_rest/tests/fixtures/organisation_opret.json
@@ -1,0 +1,37 @@
+{
+    "attributter": {
+        "organisationegenskaber": [
+            {
+                "brugervendtnoegle": "AU",
+                "organisationsnavn": "Aarhus Universitet",
+                "virkning": {
+                    "from": "2016-01-01 00:00:00+01:00",
+                    "to": "infinity"
+                }
+            }
+        ]
+    },
+    "tilstande": {
+        "organisationgyldighed": [
+            {
+                "gyldighed": "Aktiv",
+                "virkning": {
+                    "from": "2016-01-01 00:00:00+01:00",
+                    "to": "infinity"
+                }
+            }
+        ]
+    },
+    "relationer": {
+        "myndighed": [
+            {
+                "urn": "urn:dk:kommune:751",
+                "virkning": {
+                    "from": "2016-01-01 00:00:00+01:00",
+                    "to": "infinity"
+                }
+            }
+        ]
+    },
+    "note": "Automatisk indl\u00e6sning"
+}

--- a/oio_rest/tests/fixtures/organisationenhed_opret.json
+++ b/oio_rest/tests/fixtures/organisationenhed_opret.json
@@ -1,0 +1,56 @@
+{
+  "attributter": {
+    "organisationenhedegenskaber": [
+      {
+        "brugervendtnoegle": "root",
+        "enhedsnavn": "Overordnet Enhed",
+        "virkning": {
+          "from": "2016-01-01 00:00:00+01:00",
+          "to": "infinity"
+        }
+      }
+    ]
+  },
+  "tilstande": {
+    "organisationenhedgyldighed": [
+      {
+        "gyldighed": "Aktiv",
+        "virkning": {
+          "from": "2016-01-01 00:00:00+01:00",
+          "to": "infinity",
+          "from_included": true
+        }
+      }
+    ]
+  },
+  "relationer": {
+    "overordnet": [
+      {
+        "uuid": "456362c4-0ee4-4e5e-a72c-751239745e62",
+        "virkning": {
+          "from": "2016-01-01 00:00:00+01:00",
+          "to": "infinity"
+        }
+      }
+    ],
+    "tilhoerer": [
+      {
+        "uuid": "456362c4-0ee4-4e5e-a72c-751239745e62",
+        "virkning": {
+          "from": "2016-01-01 00:00:00+01:00",
+          "to": "infinity"
+        }
+      }
+    ],
+    "enhedstype": [
+      {
+        "uuid": "32547559-cfc1-4d97-94c6-70b192eff825",
+        "virkning": {
+          "from": "2016-01-01 00:00:00+01:00",
+          "to": "infinity"
+        }
+      }
+    ]
+  },
+  "note": "Automatisk indl\u00e6sning"
+}

--- a/oio_rest/tests/fixtures/organisationfunktion_opret.json
+++ b/oio_rest/tests/fixtures/organisationfunktion_opret.json
@@ -1,0 +1,73 @@
+{
+    "attributter": {
+        "organisationfunktionegenskaber": [
+            {
+                "brugervendtnoegle": "bvn",
+                "funktionsnavn": "Engagement",
+                "virkning": {
+                    "from": "2017-01-01 00:00:00+01:00",
+                    "to": "infinity"
+                }
+            }
+        ]
+    },
+    "note": "Automatisk indl\u00e6sning",
+    "relationer": {
+        "organisatoriskfunktionstype": [
+            {
+                "uuid": "32547559-cfc1-4d97-94c6-70b192eff825",
+                "virkning": {
+                    "from": "2017-01-01 00:00:00+01:00",
+                    "to": "infinity"
+                }
+            }
+        ],
+        "opgaver": [
+            {
+                "uuid": "4311e351-6a3c-4e7e-ae60-8a3b2938fbd6",
+                "virkning": {
+                    "from": "2017-01-01 00:00:00+01:00",
+                    "to": "infinity"
+                }
+            }
+        ],
+        "tilknyttedebrugere": [
+            {
+                "uuid": "53181ed2-f1de-4c4a-a8fd-ab358c2c454a",
+                "virkning": {
+                    "from": "2017-01-01 00:00:00+01:00",
+                    "to": "infinity"
+                }
+            }
+        ],
+        "tilknyttedeenheder": [
+            {
+                "uuid": "9d07123e-47ac-4a9a-88c8-da82e3a4bc9e",
+                "virkning": {
+                    "from": "2017-01-01 00:00:00+01:00",
+                    "to": "infinity"
+                }
+            }
+        ],
+        "tilknyttedeorganisationer": [
+            {
+                "uuid": "456362c4-0ee4-4e5e-a72c-751239745e62",
+                "virkning": {
+                    "from": "2017-01-01 00:00:00+01:00",
+                    "to": "infinity"
+                }
+            }
+        ]
+    },
+    "tilstande": {
+        "organisationfunktiongyldighed": [
+            {
+                "gyldighed": "Aktiv",
+                "virkning": {
+                    "from": "2017-01-01 00:00:00+01:00",
+                    "to": "infinity"
+                }
+            }
+        ]
+    }
+}

--- a/oio_rest/tests/test_oio_rest.py
+++ b/oio_rest/tests/test_oio_rest.py
@@ -21,7 +21,7 @@ from oio_rest.db import db_helpers
 from oio_rest.custom_exceptions import (BadRequestException, NotFoundException,
                                         GoneException)
 from oio_rest.oio_rest import OIOStandardHierarchy, OIORestObject
-from oio_rest import oio_rest
+from oio_rest import oio_rest, organisation
 from oio_rest.utils import test_support
 
 
@@ -279,7 +279,7 @@ class TestOIORestObject(TestCase):
         with self.app.test_request_context(data=json.dumps(data),
                                            content_type='application/json',
                                            method='POST'):
-            result = self.testclass.create_object()
+            result = organisation.Organisation.create_object()
             actual_data = json.loads(result[0].get_data(as_text=True))
             actual_code = result[1]
 
@@ -776,7 +776,7 @@ class TestOIORestObject(TestCase):
         with self.app.test_request_context(data=json.dumps(data),
                                            content_type='application/json',
                                            method='PUT'):
-            result = self.testclass.put_object(uuid)
+            result = organisation.Organisation.put_object(uuid)
             actual_data = json.loads(result[0].get_data(as_text=True))
             actual_code = result[1]
 

--- a/oio_rest/tests/test_validate.py
+++ b/oio_rest/tests/test_validate.py
@@ -25,6 +25,7 @@ from oio_rest import organisation
 from oio_rest import sag
 from oio_rest import tilstand
 from oio_rest import validate
+from oio_rest import settings
 
 from . import util
 
@@ -761,10 +762,11 @@ class TestGenerateJSONSchema(TestBase):
             'indeks' in relationer['properties']['ansatte']['items'][
                 'oneOf'][1]['properties'])
 
-    def test_create_facet_request_valid(self):
-        req = self._json_to_dict('facet_opret.json')
-        obj = 'facet'
-        validate.validate(req, obj)
+    def test_create_request_valid(self):
+        for obj in settings.REAL_DB_STRUCTURE:
+            with self.subTest(obj):
+                req = self._json_to_dict('{}_opret.json'.format(obj))
+                validate.validate(req, obj)
 
     def test_create_facet_request_invalid(self):
         req = self._json_to_dict('facet_opret.json')
@@ -776,58 +778,6 @@ class TestGenerateJSONSchema(TestBase):
         with self.assertRaises(jsonschema.exceptions.ValidationError):
             obj = 'facet'
             validate.validate(req, obj)
-
-    def test_create_bruger_request_valid(self):
-        req = self._json_to_dict('bruger_opret.json')
-        obj = 'bruger'
-        validate.validate(req, obj)
-
-    def test_create_klassifikation_request_valid(self):
-        req = self._json_to_dict('klassifikation_opret.json')
-        obj = 'klassifikation'
-        validate.validate(req, obj)
-
-    def test_create_klasse_request_valid(self):
-        req = self._json_to_dict('klasse_opret.json')
-        obj = 'klasse'
-        validate.validate(req, obj)
-
-    def test_create_aktivitet_request_valid(self):
-        req = self._json_to_dict('aktivitet_opret.json')
-        obj = 'aktivitet'
-        validate.validate(req, obj)
-
-    def test_create_tilstand_request_valid(self):
-        req = self._json_to_dict('tilstand_opret.json')
-        obj = 'tilstand'
-        validate.validate(req, obj)
-
-    def test_create_indsats_request_valid(self):
-        req = self._json_to_dict('indsats_opret.json')
-        obj = 'indsats'
-        validate.validate(req, obj)
-
-    def test_create_itsystem_request_valid(self):
-        req = self._json_to_dict('itsystem_opret.json')
-        obj = 'itsystem'
-        validate.validate(req, obj)
-
-    def test_create_loghaendelse_request_valid(self):
-        req = self._json_to_dict('loghaendelse_opret.json')
-        obj = 'loghaendelse'
-        validate.validate(req, obj)
-
-    def test_create_sag_request_valid(self):
-        req = self._json_to_dict('sag_opret.json')
-        obj = 'sag'
-        validate.validate(req, obj)
-
-    def test_create_dokument_request_valid(self):
-        '''Due to an inconsistency between the way LoRa handles
-        "DokumentVariantEgenskaber" and the specs'''
-        req = self._json_to_dict('dokument_opret.json')
-        obj = 'dokument'
-        validate.validate(req, obj)
 
     def test_create_misdirected_invalid(self):
         req = self._json_to_dict('facet_opret.json')

--- a/oio_rest/tests/test_validate.py
+++ b/oio_rest/tests/test_validate.py
@@ -46,12 +46,6 @@ class TestBase(unittest.TestCase):
         # structure
         validate.SCHEMAS = {}
 
-    def setUp(self):
-        super().setUp()
-
-        with self.assertRaises(jsonschema.exceptions.ValidationError):
-            validate.validate({})
-
 
 class TestGetMandatory(TestBase):
     def test_facet(self):
@@ -767,46 +761,10 @@ class TestGenerateJSONSchema(TestBase):
             'indeks' in relationer['properties']['ansatte']['items'][
                 'oneOf'][1]['properties'])
 
-    def test_object_type_is_organisation(self):
-        quasi_org = {
-            'attributter': {
-                "organisationegenskaber": []
-            }
-        }
-        self.assertEqual('organisation',
-                         validate.get_lora_object_type(quasi_org))
-
-    def test_object_type_is_organisationenhed(self):
-        quasi_org_enhed = {
-            'attributter': {
-                "organisationenhedegenskaber": []
-            }
-        }
-        self.assertEqual('organisationenhed',
-                         validate.get_lora_object_type(quasi_org_enhed))
-
-    def test_raise_exception_if_obj_egenskaber_not_set(self):
-        quasi_org = {
-            'attributter': {
-                "invalid-egenskaber": []
-            }
-        }
-        with self.assertRaises(jsonschema.exceptions.ValidationError):
-            validate.get_lora_object_type(quasi_org)
-
-    def test_raise_exception_if_attributter_not_set(self):
-        quasi_org = {
-            'invalid-attributter': {
-                "organisationegenskaber": []
-            }
-        }
-        with self.assertRaises(jsonschema.exceptions.ValidationError):
-            validate.get_lora_object_type(quasi_org)
-
     def test_create_facet_request_valid(self):
         req = self._json_to_dict('facet_opret.json')
-        obj = validate.get_lora_object_type(req)
-        jsonschema.validate(req, validate.get_schema(obj))
+        obj = 'facet'
+        validate.validate(req, obj)
 
     def test_create_facet_request_invalid(self):
         req = self._json_to_dict('facet_opret.json')
@@ -816,60 +774,67 @@ class TestGenerateJSONSchema(TestBase):
             req['attributter']['facetegenskaber'][0].pop('supplement')
 
         with self.assertRaises(jsonschema.exceptions.ValidationError):
-            obj = validate.get_lora_object_type(req)
-            jsonschema.validate(req, validate.get_schema(obj))
+            obj = 'facet'
+            validate.validate(req, obj)
 
     def test_create_bruger_request_valid(self):
         req = self._json_to_dict('bruger_opret.json')
-        obj = validate.get_lora_object_type(req)
-        jsonschema.validate(req, validate.get_schema(obj))
+        obj = 'bruger'
+        validate.validate(req, obj)
 
     def test_create_klassifikation_request_valid(self):
         req = self._json_to_dict('klassifikation_opret.json')
-        obj = validate.get_lora_object_type(req)
-        jsonschema.validate(req, validate.get_schema(obj))
+        obj = 'klassifikation'
+        validate.validate(req, obj)
 
     def test_create_klasse_request_valid(self):
         req = self._json_to_dict('klasse_opret.json')
-        obj = validate.get_lora_object_type(req)
-        jsonschema.validate(req, validate.get_schema(obj))
+        obj = 'klasse'
+        validate.validate(req, obj)
 
     def test_create_aktivitet_request_valid(self):
         req = self._json_to_dict('aktivitet_opret.json')
-        obj = validate.get_lora_object_type(req)
-        jsonschema.validate(req, validate.get_schema(obj))
+        obj = 'aktivitet'
+        validate.validate(req, obj)
 
     def test_create_tilstand_request_valid(self):
         req = self._json_to_dict('tilstand_opret.json')
-        obj = validate.get_lora_object_type(req)
-        jsonschema.validate(req, validate.get_schema(obj))
+        obj = 'tilstand'
+        validate.validate(req, obj)
 
     def test_create_indsats_request_valid(self):
         req = self._json_to_dict('indsats_opret.json')
-        obj = validate.get_lora_object_type(req)
-        jsonschema.validate(req, validate.get_schema(obj))
+        obj = 'indsats'
+        validate.validate(req, obj)
 
     def test_create_itsystem_request_valid(self):
         req = self._json_to_dict('itsystem_opret.json')
-        obj = validate.get_lora_object_type(req)
-        jsonschema.validate(req, validate.get_schema(obj))
+        obj = 'itsystem'
+        validate.validate(req, obj)
 
     def test_create_loghaendelse_request_valid(self):
         req = self._json_to_dict('loghaendelse_opret.json')
-        obj = validate.get_lora_object_type(req)
-        jsonschema.validate(req, validate.get_schema(obj))
+        obj = 'loghaendelse'
+        validate.validate(req, obj)
 
     def test_create_sag_request_valid(self):
         req = self._json_to_dict('sag_opret.json')
-        obj = validate.get_lora_object_type(req)
-        jsonschema.validate(req, validate.get_schema(obj))
+        obj = 'sag'
+        validate.validate(req, obj)
 
     def test_create_dokument_request_valid(self):
         '''Due to an inconsistency between the way LoRa handles
         "DokumentVariantEgenskaber" and the specs'''
         req = self._json_to_dict('dokument_opret.json')
-        obj = validate.get_lora_object_type(req)
-        jsonschema.validate(req, validate.get_schema(obj))
+        obj = 'dokument'
+        validate.validate(req, obj)
+
+    def test_create_misdirected_invalid(self):
+        req = self._json_to_dict('facet_opret.json')
+
+        # note: 'klasse' ≠ 'facet'!
+        with self.assertRaises(jsonschema.exceptions.ValidationError):
+            validate.validate(req, 'klasse')
 
 
 class TestFacetSystematically(TestBase):


### PR DESCRIPTION
This fixes some issues with creating objects with additional
attributes. Rather than extract the OIO object type from the request,
we simply forward the knowledge we already have.

The code currently fails when faced with requests containing two or
more attributes. Simply removing the logic for extracting the type is
easier than fixing it.

I removed the explicit tests for this functionality, and adjusted a
few tests that implicitly relied on this behaviour, by performing a
request targeting the wrong type. While at it, I added a test for
that.