### PR TITLE
#27285 dummy test fixtures

### DIFF
--- a/oio_rest/requirements-test.txt
+++ b/oio_rest/requirements-test.txt
@@ -2,7 +2,7 @@
 Flask-Testing
 testing.postgresql
 tap.py
-unittest-xml-reporting
+unittest-xml-reporting<2.3.0
 mock
 requests_mock
 coverage


### PR DESCRIPTION
This PR exposes logic to easily load a dump using `psql`. This is primarily useful for fast loading within the MO testsuite.

https://redmine.magenta-aps.dk/issues/27285