### PR TITLE
Specify specific version of psycopg2 in requirements.

### DIFF
--- a/oio_rest/requirements.txt
+++ b/oio_rest/requirements.txt
@@ -1,6 +1,6 @@
 requests==2.21.0
 Flask==1.0.2
-psycopg2>=2.7
+psycopg2==2.7
 pexpect==4.6.0
 python-dateutil==2.7.5
 pika==0.13.0


### PR DESCRIPTION
We currently use PersistentConnectionPool which has been deprecated in version 2.8