### PR TITLE
Make Jenkins fail on flake8 errors

### DIFF
--- a/oio_rest/oio_rest/db/db_helpers.py
+++ b/oio_rest/oio_rest/db/db_helpers.py
@@ -93,7 +93,7 @@ def get_relation_names(class_name):
     if len(_relation_names) == 0:
         for c, fs in settings.REAL_DB_STRUCTURE.items():
             _relation_names[c] = (
-                fs['relationer_nul_til_en'] +  # noqa
+                fs['relationer_nul_til_en'] +
                 fs['relationer_nul_til_mange']
             )
     return _relation_names[class_name.lower()]
@@ -336,7 +336,7 @@ class NamedTupleAdapter(object):
     def getquoted(self):
         values = list(map(self.prepare_and_adapt, self._tuple_obj))
         values = [v.getquoted() for v in values]
-        sql = (b'ROW(' + b','.join(values) + b') :: ' +  # noqa
+        sql = (b'ROW(' + b','.join(values) + b') :: ' +
                self._tuple_obj.__class__.__name__.encode('ascii'))
         return sql
 
@@ -357,7 +357,7 @@ class AktoerAttrAdapter(NamedTupleAdapter):
             qaa.repraesentation_urn
         ]
 
-        sql = (b'ROW(' + b','.join(values) + b') :: ' +  # noqa
+        sql = (b'ROW(' + b','.join(values) + b') :: ' +
                self._tuple_obj.__class__.__name__.encode('ascii'))
         return sql
 

--- a/oio_rest/oio_rest/dokument.py
+++ b/oio_rest/oio_rest/dokument.py
@@ -51,7 +51,7 @@ class Dokument(OIORestObject):
                                          hierarchy,
                                          cls.__name__.lower())
         uuid_regex = (
-            "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}" +  # noqa
+            "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}"
             "-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
         )
         date_path_regex = (

--- a/oio_rest/oio_rest/oio_rest.py
+++ b/oio_rest/oio_rest/oio_rest.py
@@ -436,7 +436,7 @@ class OIORestObject(object):
         if exists:
             livscyklus = db.get_life_cycle_code(cls.__name__, uuid)
             if (
-                livscyklus == db.Livscyklus.PASSIVERET.value or  # noqa
+                livscyklus == db.Livscyklus.PASSIVERET.value or
                 livscyklus == db.Livscyklus.SLETTET.value
             ):
                 deleted_or_passive = True
@@ -564,7 +564,7 @@ class OIORestObject(object):
                                          class_name)
         cls_fields_url = "{0}/{1}".format(class_url, "fields")
         uuid_regex = (
-            "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}" +  # noqa
+            "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}"
             "-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
         )
         object_url = '{0}/<regex("{1}"):uuid>'.format(

--- a/oio_rest/run_tests.sh
+++ b/oio_rest/run_tests.sh
@@ -36,7 +36,7 @@ $PYTHON -m pip install 'pip>=18.1' 'setuptools>=40'
 $PYTHON -m pip install -e '.[tests]'
 
 # Execute tests
-$PYTHON -m flake8 --exit-zero
+$PYTHON -m flake8
 
 $PYTHON -m coverage run -m xmlrunner \
         --verbose --buffer --output build/reports "$@"

--- a/oio_rest/setup.cfg
+++ b/oio_rest/setup.cfg
@@ -10,7 +10,7 @@ testpaths = tests
 addopts = --cov=oio_rest --cov-report=xml --cov-branch --junitxml=build/reports/oio_rest.xml
 
 [flake8]
-ignore = N999
+ignore = N999, W504
 select = E,D,F,W,C,T,N,H
 exclude =
         oio_rest/settings.py

--- a/oio_rest/tests/test_db.py
+++ b/oio_rest/tests/test_db.py
@@ -15,8 +15,9 @@ from mock import MagicMock, call, patch
 
 from oio_rest import db
 from oio_rest import app
-from oio_rest.custom_exceptions import (BadRequestException, DBException,
-                                        NotFoundException)
+from oio_rest.custom_exceptions import (
+    BadRequestException, DBException, NotFoundException
+)
 
 
 class TestDB(flask_testing.TestCase):
@@ -55,7 +56,9 @@ class TestDB(flask_testing.TestCase):
 
     @patch('oio_rest.db.get_relation_field_type')
     def test_convert_relation_value_journaldokument(self, mock_get_rel):
-        from oio_rest.db.db_helpers import JournalDokument, OffentlighedUndtaget
+        from oio_rest.db.db_helpers import (
+            JournalDokument, OffentlighedUndtaget
+        )
 
         # Arrange
         mock_get_rel.return_value = "journaldokument"

--- a/oio_rest/tests/test_rest_dokument.py
+++ b/oio_rest/tests/test_rest_dokument.py
@@ -15,18 +15,14 @@ from tests import util
 
 class TestDokument(util.TestCase):
     def test_create_dokument_empty_dict(self):
-        '''Not sure why this happens?'''
+        """Not sure why this happens?"""
         self.assertRequestResponse(
-            "/dokument/dokument",
-            {'uuid': None},
-            json={},
-            status_code=400,
+            "/dokument/dokument", {"uuid": None}, json={}, status_code=400
         )
 
     def test_create_dokument_missing_files(self):
         result = self.client.post(
-            "/dokument/dokument",
-            json=util.get_fixture("dokument_opret.json"),
+            "/dokument/dokument", json=util.get_fixture("dokument_opret.json")
         ).get_json()
         self.assertNotIn("uuid", result)
         self.assertTrue(result["message"])
@@ -38,11 +34,22 @@ class TestDokument(util.TestCase):
                 "/dokument/dokument",
                 content_type="multipart/form-data",
                 data={
-                    "json": util.get_fixture("dokument_opret.json", as_text=False),
-                    "del_indhold1": ("tests/fixtures/test.txt", "del_indhold1"),
-                    "del_indhold2": ("tests/fixtures/test.docx", "del_indhold2"),
-                    "del_indhold3": ("tests/fixtures/test.xls", "del_indhold3"),
-                }
+                    "json": util.get_fixture(
+                        "dokument_opret.json", as_text=False
+                    ),
+                    "del_indhold1": (
+                        "tests/fixtures/test.txt",
+                        "del_indhold1",
+                    ),
+                    "del_indhold2": (
+                        "tests/fixtures/test.docx",
+                        "del_indhold2",
+                    ),
+                    "del_indhold3": (
+                        "tests/fixtures/test.xls",
+                        "del_indhold3",
+                    ),
+                },
             ).get_json()
             self.assertTrue(is_uuid(result["uuid"]))
             upload_uuid = result["uuid"]  # the subtests rely on this variable
@@ -54,11 +61,22 @@ class TestDokument(util.TestCase):
                 "/dokument/dokument/%s" % import_uuid,
                 content_type="multipart/form-data",
                 data={
-                    "json": util.get_fixture("dokument_opret.json", as_text=False),
-                    "del_indhold1": ("tests/fixtures/test.txt", "del_indhold1"),
-                    "del_indhold2": ("tests/fixtures/test.docx", "del_indhold2"),
-                    "del_indhold3": ("tests/fixtures/test.xls", "del_indhold3"),
-                }
+                    "json": util.get_fixture(
+                        "dokument_opret.json", as_text=False
+                    ),
+                    "del_indhold1": (
+                        "tests/fixtures/test.txt",
+                        "del_indhold1",
+                    ),
+                    "del_indhold2": (
+                        "tests/fixtures/test.docx",
+                        "del_indhold2",
+                    ),
+                    "del_indhold3": (
+                        "tests/fixtures/test.xls",
+                        "del_indhold3",
+                    ),
+                },
             ).get_json()
             self.assertTrue(is_uuid(result["uuid"]))
             self.assertEqual(result["uuid"], import_uuid)
@@ -66,9 +84,10 @@ class TestDokument(util.TestCase):
         files = []
         with self.subTest("List files / get content urls"):
             for r in self.client.get(
-                "dokument/dokument",
-                query_string={"uuid": upload_uuid},
-            ).get_json()["results"][0][0]["registreringer"][0]["varianter"][0]["dele"]:
+                "dokument/dokument", query_string={"uuid": upload_uuid}
+            ).get_json()["results"][0][0]["registreringer"][0]["varianter"][0][
+                "dele"
+            ]:
                 path = r["egenskaber"][0]["indhold"]
                 if path.startswith("store:"):
                     files.append(path[6:])
@@ -83,7 +102,9 @@ class TestDokument(util.TestCase):
             with self.subTest("Download dokument", filename=filename):
                 self.assertEqual(
                     b"This is a test",
-                    self.client.get("dokument/dokument/%s" % filename).get_data()
+                    self.client.get(
+                        "dokument/dokument/%s" % filename
+                    ).get_data(),
                 )
 
         with self.subTest("Search on DokumentDel relations"):
@@ -97,8 +118,8 @@ class TestDokument(util.TestCase):
                         "deltekst": "doc_deltekst2B",
                         "underredigeringaf": "urn:cpr8883394",
                         "uuid": upload_uuid,
-                    }
-                ).get_json()
+                    },
+                ).get_json(),
             )
 
         with self.subTest("Update dokument"):
@@ -106,7 +127,9 @@ class TestDokument(util.TestCase):
                 "/dokument/dokument",
                 content_type="multipart/form-data",
                 data={
-                    "json": util.get_fixture("dokument_opdater.json", as_text=False),
+                    "json": util.get_fixture(
+                        "dokument_opdater.json", as_text=False
+                    )
                 },
                 query_string={"uuid": upload_uuid},
             )
@@ -114,8 +137,7 @@ class TestDokument(util.TestCase):
 
         with self.subTest("Download updated dokument"):
             result = self.client.get(
-                "dokument/dokument",
-                query_string={"uuid": upload_uuid},
+                "dokument/dokument", query_string={"uuid": upload_uuid}
             ).get_json()
             self.assertEqual(
                 result["results"][0][0]["registreringer"][0]["note"],
@@ -124,12 +146,16 @@ class TestDokument(util.TestCase):
 
         with self.subTest("Update dokument with file upload"):
             result = self.client.patch(
-                 "/dokument/dokument",
+                "/dokument/dokument",
                 content_type="multipart/form-data",
                 data={
-                    "json": util.get_fixture("dokument_opdater2.json", as_text=False),
-                    "del_indhold1_opdateret": ("tests/fixtures/test2.txt",
-                    "del_indhold1_opdateret"),
+                    "json": util.get_fixture(
+                        "dokument_opdater2.json", as_text=False
+                    ),
+                    "del_indhold1_opdateret": (
+                        "tests/fixtures/test2.txt",
+                        "del_indhold1_opdateret",
+                    ),
                 },
                 query_string={"uuid": upload_uuid},
             )
@@ -137,12 +163,20 @@ class TestDokument(util.TestCase):
 
         with self.subTest("Download updated dokument 2"):
             result = self.client.get(
-                "dokument/dokument", query_string={"uuid": upload_uuid})
+                "dokument/dokument", query_string={"uuid": upload_uuid}
+            )
             self.assertEqual(result.status_code, 200)
-            for r in result.get_json()["results"][0][0]["registreringer"][0]["varianter"][0]["dele"]:
+            for r in result.get_json()["results"][0][0]["registreringer"][0][
+                "varianter"
+            ][0]["dele"]:
                 path = r["egenskaber"][0]["indhold"]
                 if path.startswith("store:"):
-                    if b"This is an updated test" in self.client.get("dokument/dokument/%s" % path[6:]).get_data():
+                    if (
+                        b"This is an updated test"
+                        in self.client.get(
+                            "dokument/dokument/%s" % path[6:]
+                        ).get_data()
+                    ):
                         break
             else:
                 raise NotImplementedError("Uploaded file was not updated")
@@ -236,7 +270,8 @@ class TestDokument(util.TestCase):
             r = self.client.get(
                 "dokument/dokument",
                 query_string={
-                    "ejer": "Organisation=ef2713ee-1a38-4c23-8fcb-3c4331262194",
+                    "ejer":
+                    "Organisation=ef2713ee-1a38-4c23-8fcb-3c4331262194",
                     "uuid": import_uuid,
                 },
             )

--- a/oio_rest/tests/test_rest_sag.py
+++ b/oio_rest/tests/test_rest_sag.py
@@ -114,21 +114,21 @@ class TestSag(util.TestCase):
 
     @unittest.expectedFailure
     def test_sag_8(self):
-        "Search for journaldokument.offentligtundtaget.alternativtitel relation"
+        "Search journaldokument.offentligtundtaget.alternativtitel relation"
         # unsupported argument:
         # journaldokument.offenligtundtaget.alternativtitel
         search8 = self.client.get(
             "sag/sag",
             query_string={
-                "journaldokument.offentligtundtaget.alternativtitel": "Fortroligt",
-                "uuid": self.uuid,
+                "journaldokument.offentligtundtaget.alternativtitel":
+                "Fortroligt", "uuid": self.uuid,
             },
         )
         self.assertEqual(search8.status_code, 200)
         self.assertEqual(search8.get_json()["results"][0][0], self.uuid)
 
     def test_sag_9(self):
-        "Search for wrong journaldokument.offentligtundtaget.alternativtitel relation"
+        "Wrong journaldokument.offentligtundtaget.alternativtitel relation"
         # unsupported argument:
         # journaldokument.offenligtundtaget.alternativtitel
         search9 = self.client.get(


### PR DESCRIPTION
For some time, Jenkins has ignored Flake8 warnings, and this has led to a certain deterioration, as Python code with PEP-8 discrepancies, unused imports and variables etc. has been introduced. 

I propose to fail on Flake8 warnings to impose that as our standard. `#  noqa` is allowed, but you must be prepared to argue why it is necessary.