### PR TITLE
Feature/30312 copy services

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,6 +15,7 @@ Content
    user/overview.rst
    Middle-level overview (in danish) <user/praesentation.rst>
    user/installation.rst
+   user/database.rst
    user/objects.rst
    user/api.rst
    user/log-haendelse.rst

--- a/doc/user/database.rst
+++ b/doc/user/database.rst
@@ -1,0 +1,27 @@
+.. _Database:
+
+========
+Database
+========
+
+.. todo::
+
+   Document the database in `#30317
+   <https://redmine.magenta-aps.dk/issues/30317>`_.
+
+.. _db_user_ext_init:
+
+Database, user and extensions initialization
+===========================================
+
+
+.. _db_object_init:
+
+Object initialization
+=====================
+
+To initialize the database, run::
+
+    python -m oio_rest initdb
+
+For more info run ``python -m oio_rest initdb --help``.

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -8,18 +8,18 @@ below. Use the docker image or a Python package in a virtual environment.
 
 .. tip::
 
-   TL;DR: To get a running development environment with postgres, rabbitmq and
-   mox, run:
+   TL;DR: To get a running development environment with postgres and mox, run:
 
    .. code-block:: bash
 
       git clone https://github.com/magenta-aps/mox.git
       cd mox
-      docker-compose up -d --build
+      docker-compose up -d --build mox
 
 .. todo::
 
    Document how to install test dependencies when it is formalized in #28489.
+
 
 Docker
 ======
@@ -34,15 +34,78 @@ All releases are pushed to Docker Hub at `magentaaps/mox
 To run mox in docker you need a running docker. To install docker we refer you
 to the `official documentation <https://docs.docker.com/install/>`_.
 
-The container requires a connection to a postgres database. It is configured
-with the environment variables :py:data:`DB_HOST`, :py:data:`DB_USER` and
-:py:data:`DB_PASSWORD`. You can start a the container with:
+
+Database
+--------
+
+The container requires a connection to a postgres database. Read :ref:`Database`
+for a complete description.
+
+Remember if you set :data:`DB_HOST` to ``localhost`` the container will try to
+connect to a database in the same container , not the host machine.
+
+You will need to :ref:`initialize the database, user and
+extensions<db_user_ext_init>`. The docker image contains a few scripts to do
+this easily. They are designed to work with the `official postgres docker image
+<https://hub.docker.com/_/postgres>`_. You can copy the scripts from the docker
+image by running:
 
 .. code-block:: bash
 
-    docker run -p 8080:8080 -e DB_HOST=<IP of DB host> -e DB_USER=mox -e DB_PASSWORD=mox magentaaps/mox:latest
+   # To a docker volume named postgres-initdb.d
+   docker run \
+     --rm \
+     -v postgres-initdb.d:/postgres-initdb.d \
+     --entrypoint="" \
+     --user=root \
+     magentaaps/mox:latest \
+     cp -r /code/docker/postgres-initdb.d/. /postgres-initdb.d
 
-This will pull the image from Docker Hub and starts a container in the
+   # To a directory named postgres-initdb.d
+   docker run \
+     --rm \
+     -v $PWD/postgres-initdb.d:/postgres-initdb.d \
+     --entrypoint="" \
+     --user=root \
+     magentaaps/mox:latest \
+     cp -r /code/docker/postgres-initdb.d/. /postgres-initdb.d
+
+
+These scripts can now easily be mounted into the postgres docker image. They
+require the environment variables ``DB_NAME``, ``DB_USER`` and ``DB_PASSWORD``
+to be set. It is also recommended to set ``POSTGRESS_PASSWORD`` for the
+``SUPERUSER`` in postgres. To start a postgres docker image run:
+
+.. code-block:: bash
+
+   docker run \
+     -v postgres-initdb.d:/docker-entrypoint-initdb.d \
+     -e DB_NAME=mox \
+     -e DB_USER=mox \
+     -e DB_PASSWORD=mox \
+     -e POSTGRES_PASSWORD=mox \
+     postgres:9.6
+
+The mox docker image will automatically :ref:`initialize the database
+objects<db_object_init>` for on the first startup.
+
+
+Run the container
+-----------------
+
+When you have initialized the database with :ref:`database, user and
+extensions<db_user_ext_init>`, you can start a the container with:
+
+.. code-block:: bash
+
+    docker run \
+      -p 8080:8080 \
+      -e DB_HOST=<IP of DB host> \
+      -e DB_USER=mox \
+      -e DB_PASSWORD=mox \
+      magentaaps/mox:latest
+
+This will pull the image from Docker Hub and start a container in the
 foreground. The ``-p 8080:8080`` `binds port
 <https://docs.docker.com/engine/reference/commandline/run/#publish-or-expose-port--p---expose>`_
 ``8080`` of the host machine to port ``8080`` on the container. The ``-e`` `sets
@@ -59,10 +122,6 @@ finally
 
 when the gunicorn server starts up. You should now be able to reach the server
 from the host at ``http://localhost:8080``.
-
-
-Remember if you set ``DB_HOST=localhost`` the container will try to connect to
-a database in the same container, not the host machine.
 
 For other setting you can set, see :ref:`settings`.
 
@@ -111,13 +170,11 @@ set the same user as owner of the directory you bind.
 Docker-compose
 ==============
 
-You can use ``docker-compose`` to start up mox and related service such as
-postgres and rabbitmq.
+You can use ``docker-compose`` to start up mox and postgres.
 
 A :file:`docker-compose.yml` for development is included. It automatically
-starts up `postgres <https://hub.docker.com/_/postgres>`_ and `rabbitmq
-<https://hub.docker.com/_/rabbitmq>`_. It sets the environment variabels to
-connect them.
+starts up `postgres <https://hub.docker.com/_/postgres>`_. It sets the
+environment variables to connect them.
 
 It also mounts the current directory in the container and automatically restarts
 the server on changes. This enables you to edit the files in :file:`oio_rest`
@@ -127,7 +184,8 @@ To pull the images and start the three service run:
 
 .. code-block:: bash
 
-    docker-compose up -d --build
+
+    docker-compose up -d --build mox
 
 The ``-d`` flag move the services to the background. You can inspect the output
 of them with ``docker-compose logs <name>`` where ``<name>`` is the name of the
@@ -137,6 +195,14 @@ docker image for ``oio_rest`` from the local :file:`Dockerfile`.
 To stop the service again run ``docker-compose stop``. This will stop the
 services, but the data will persist. To completely remove the containers and
 data run ``docker-compose down``.
+
+The :file:`docker-compose.yml` file contains a service named ``mox-cp``. Its
+purpose is to copy the files needed to :ref:`initialize the database, user and
+extensions<db_user_ext_init>` to a volume. This volume can then be mounted to
+the postgres image to automatically initialize the database. This functionality
+is not needed by default because the needed files are mounted directly from the
+host. It is included as an example when you want to use an environment closer to
+production.
 
 
 From source
@@ -186,11 +252,11 @@ to :py:data:`DB_HOST`, :py:data:`DB_USER` and :py:data:`DB_PASSWORD`.
 Database initialization
 -----------------------
 
-To initialize the database, run::
+.. todo::
 
-    python -m oio_rest initdb
+   Refer to relavant section in :ref:`database` when it is written in `#30317
+   <https://redmine.magenta-aps.dk/issues/30317>`_.
 
-For more info run ``python -m oio_rest initdb --help``.
 
 Run
 ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,3 +26,22 @@ services:
       - docker/db.env
     volumes:
       - ./docker/postgres-initdb.d/:/docker-entrypoint-initdb.d
+      #- postgres-initdb.d:/docker-entrypoint-initdb.d
+
+
+  # The following service is to copy the *.sql file needed to initialize the
+  # database with user and extentions to a volume. It is not needed when the
+  # volume `./docker/postgres-initdb.d/:/docker-entrypoint-initdb.d` is bound in
+  # mox-db above.
+  mox-cp:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    user: root
+    entrypoint: []
+    command: ["cp", "-r", "/code/docker/postgres-initdb.d/.", "/postgres-initdb.d"]
+    volumes:
+      - postgres-initdb.d:/postgres-initdb.d
+
+volumes:
+  postgres-initdb.d:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       #- postgres-initdb.d:/docker-entrypoint-initdb.d
 
 
-  # The following service is to copy the *.sql file needed to initialize the
+  # The following service is to copy the scripts needed to initialize the
   # database with user and extentions to a volume. It is not needed when the
   # volume `./docker/postgres-initdb.d/:/docker-entrypoint-initdb.d` is bound in
   # mox-db above.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -59,7 +59,7 @@ RUN pip3 install -r oio_rest/requirements.txt
 
 
 # Copy and install application.
-COPY docker/docker-entrypoint.sh ./docker/docker-entrypoint.sh
+COPY docker ./docker
 COPY oio_rest ./oio_rest
 COPY README.rst .
 COPY LICENSE .


### PR DESCRIPTION
This is a documentation and sample for how to move the `.sql`-files from inside the `mox` image to the postgres image where they are needed. 