### PR TITLE
Feature/30684 fix install sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -81,8 +81,8 @@ fi
 
 
 printf "# Initialize database\n"
-sudo -u postgres env DB_USER=mox DB_PASSWORD=mox $BASE_DIR/docker/postgres-initdb.d/10-init-db.sh
-sudo -u postgres $BASE_DIR/docker/postgres-initdb.d/20-create-extensions.sh
+sudo -u postgres env DB_USER=mox DB_PASSWORD=mox DB_NAME=mox $BASE_DIR/docker/postgres-initdb.d/10-init-db.sh
+sudo -u postgres env DB_NAME=mox $BASE_DIR/docker/postgres-initdb.d/20-create-extensions.sh
 $BASE_DIR/python-env/bin/python -m oio_rest initdb
 
 


### PR DESCRIPTION
This pull request fixes a minor error (a missing environment variable) which caused `install.sh` to fail, which also meant that the tests could not be run.

